### PR TITLE
fix(release): run release script via uv so it has deps, break commit hygiene into its own action

### DIFF
--- a/.github/workflows/code_quality.yml
+++ b/.github/workflows/code_quality.yml
@@ -10,62 +10,6 @@ on:
       - alpha
 
 jobs:
-  commitlint:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - name: Set up NodeJS
-        uses: actions/setup-node@v4
-        with:
-          node-version: "lts/*"
-      - name: Install commitlint
-        run: npm i -g @commitlint/cli @commitlint/config-conventional
-      - name: Commitlint
-        run: commitlint --from "origin/${{ github.base_ref }}" --to "origin/${{ github.head_ref }}"
-
-  semantic_release_dryrun:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-      - name: Set up NodeJS
-        uses: actions/setup-node@v4
-        with:
-          node-version: "lts/*"
-      - name: Install semantic-release dependencies
-        run: npm install --global semantic-release @semantic-release/exec @semantic-release/git
-      - name: Check out the target branch and merge onto it
-        run: |
-          git fetch origin ${{ github.base_ref }}:${{ github.base_ref }}
-          git fetch origin ${{ github.head_ref }}:${{ github.head_ref }}
-          git checkout ${{ github.base_ref }}
-          git merge --ff-only ${{ github.head_ref }}
-      - name: Run Semantic Release as a dry run
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          unset GITHUB_ACTIONS GITHUB_REF GITHUB_EVENT_NAME
-          semantic-release --dry-run --no-ci
-      - name: Comment release notes on the PR
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const fs = require('fs');
-            const versionNumber = fs.readFileSync("release_version.txt").toString().trim();
-            const releaseNotes = fs.readFileSync("release_notes.txt").toString().trim();
-
-            const commentBody = `Merging this PR will release \`${versionNumber}\` with the following release notes:\n\n${releaseNotes}`
-
-            github.rest.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: commentBody
-            });
-
   Ruff:
     runs-on: ubuntu-latest
     strategy:
@@ -84,6 +28,7 @@ jobs:
         run: uv sync --frozen
       - name: Ruff - ${{ matrix.python-version }}
         run: uv run ruff check
+
   Ruff-Format:
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/commit_hygiene.yml
+++ b/.github/workflows/commit_hygiene.yml
@@ -1,0 +1,63 @@
+name: Commit Hygiene
+on:
+  pull_request:
+    branches:
+      - main
+      - alpha
+
+jobs:
+  commitlint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Set up NodeJS
+        uses: actions/setup-node@v4
+        with:
+          node-version: "lts/*"
+      - name: Install commitlint
+        run: npm i -g @commitlint/cli @commitlint/config-conventional
+      - name: Commitlint
+        run: commitlint --from "origin/${{ github.base_ref }}" --to "origin/${{ github.head_ref }}"
+
+  semantic_release_dryrun:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Set up NodeJS
+        uses: actions/setup-node@v4
+        with:
+          node-version: "lts/*"
+      - name: Install semantic-release dependencies
+        run: npm install --global semantic-release @semantic-release/exec @semantic-release/git
+      - name: Check out the target branch and merge onto it
+        run: |
+          git fetch origin ${{ github.base_ref }}:${{ github.base_ref }}
+          git fetch origin ${{ github.head_ref }}:${{ github.head_ref }}
+          git checkout ${{ github.base_ref }}
+          git merge --ff-only ${{ github.head_ref }}
+      - name: Run Semantic Release as a dry run
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          unset GITHUB_ACTIONS GITHUB_REF GITHUB_EVENT_NAME
+          semantic-release --dry-run --no-ci
+      - name: Comment release notes on the PR
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const versionNumber = fs.readFileSync("release_version.txt").toString().trim();
+            const releaseNotes = fs.readFileSync("release_notes.txt").toString().trim();
+
+            const commentBody = `Merging this PR will release \`${versionNumber}\` with the following release notes:\n\n${releaseNotes}`
+
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: commentBody
+            });

--- a/.github/workflows/semantic_release.yml
+++ b/.github/workflows/semantic_release.yml
@@ -15,6 +15,12 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: "lts/*"
+      - name: Set up Python 3.13
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+      - name: Install uv
+        run: pip install --upgrade pip && pip install uv
       - name: Install semantic-release dependencies
         run: npm install --global semantic-release @semantic-release/exec @semantic-release/git
       - name: Run Semantic Release

--- a/.releaserc
+++ b/.releaserc
@@ -13,7 +13,7 @@
     [
       "@semantic-release/exec",
       {
-        "prepareCmd": "python .github/utils/update_version.py ${nextRelease.version} && uv lock",
+        "prepareCmd": "uv run .github/utils/update_version.py ${nextRelease.version} && uv lock",
         "verifyReleaseCmd": "echo \"${nextRelease.version}\" > release_version.txt",
         "generateNotesCmd": "echo \"${nextRelease.notes}\" > release_notes.txt"
       }


### PR DESCRIPTION
- Moved "commit hygiene" checks to their own file which only runs on new PRs. These checks were running on the branch after merge, and failing because they aren't valid for anything but a PR.
- Updated the "semantic release" action to set up uv and run inside it. This allows the release hook to access dev dependencies, in this case `tomlkit`.