### PR TITLE
chore(ci): lean into pre-commit in CI

### DIFF
--- a/.github/workflows/code_quality.yml
+++ b/.github/workflows/code_quality.yml
@@ -1,4 +1,4 @@
-name: Tests and Code Quality
+name: PR Checks
 on:
   push:
     branches:
@@ -10,43 +10,22 @@ on:
       - alpha
 
 jobs:
-  Ruff:
+  Precommit:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: [3.9, 3.13]
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
-        with:
-          python-version: ${{ matrix.python-version }}
       - name: Install uv
-        run: pip install --upgrade pip && pip install uv
-      - name: Install dependencies
-        run: uv sync --frozen
-      - name: Ruff - ${{ matrix.python-version }}
-        run: uv run ruff check
-
-  Ruff-Format:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: [3.9, 3.13]
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: astral-sh/setup-uv@v5
+      - name: Install pre-commit
+        run: uv tool install pre-commit --with pre-commit-uv
+      - name: Run pre-commit
+        run: pre-commit run --all-files --show-diff-on-failure
+      - name: Cache pre-commit
+        uses: actions/cache@v4
         with:
-          python-version: ${{ matrix.python-version }}
-      - name: Install uv
-        run: pip install --upgrade pip && pip install uv
-      - name: Install dependencies
-        run: uv sync --frozen
-      - name: Ruff-Format - ${{ matrix.python-version }}
-        run: uv run ruff format --check
+          path: ~/.cache/pre-commit
+          key: ${{ runner.os }}-pre-commit-cache
 
   MyPy:
     runs-on: ubuntu-latest
@@ -56,16 +35,13 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
-        with:
-          python-version: ${{ matrix.python-version }}
       - name: Install uv
-        run: pip install --upgrade pip && pip install uv
-      - name: Install dependencies
-        run: uv sync --frozen
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+          python-version: ${{ matrix.python-version }}
       - name: MyPy - ${{ matrix.python-version }}
-        run: uv run mypy .
+        run: uv run --locked mypy .
 
   Pytest:
     runs-on: ubuntu-latest
@@ -75,13 +51,10 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
-        with:
-          python-version: ${{ matrix.python-version }}
       - name: Install uv
-        run: pip install --upgrade pip && pip install uv
-      - name: Install dependencies
-        run: uv sync --frozen
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+          python-version: ${{ matrix.python-version }}
       - name: Pytest + Coverage - ${{ matrix.python-version }}
-        run: uv run pytest
+        run: uv run --locked pytest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,25 +1,20 @@
 # By default, run each hook only in the standard pre-commit stage
+default_install_hook_types: [pre-commit, commit-msg]
 default_stages: [pre-commit]
 
 # Pre-commit hooks.   Configuration examples at https://pre-commit.com/
 repos:
-  - repo: https://github.com/ivellios/pre_ticket
-    rev: v1.1.0
-    hooks:
-      - id: pre_ticket
-        language_version: python3.9
-        stages: [commit-msg]
-        args: ['--regex=[a-zA-Z]+/(?P<ticket>\w+-\d+)-.*', '--format={ticket} - {message}']
-
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v5.0.0
     hooks:
       - id: trailing-whitespace
+      - id: end-of-file-fixer
       - id: check-merge-conflict
       - id: check-yaml
         args:
           - --unsafe
-      - id: end-of-file-fixer
+      - id: check-json
+      - id: check-toml
 
   - repo: https://github.com/charliermarsh/ruff-pre-commit
     rev: 'v0.11.6'
@@ -29,10 +24,22 @@ repos:
 
   - repo: local
     hooks:
+      - id: uv-lock
+        name: uv-lock
+        language: system
+        entry: uv lock
+        files: ^pyproject\.toml$
+        pass_filenames: false
       - id: mypy
         name: mypy
         language: system
         entry: uv run mypy .
         types: [python]
-        require_serial: true
         pass_filenames: false
+
+  - repo: https://github.com/alessandrojcm/commitlint-pre-commit-hook
+    rev: v9.22.0
+    hooks:
+      - id: commitlint
+        stages: [commit-msg]
+        additional_dependencies: ['@commitlint/config-conventional']


### PR DESCRIPTION
* Add commitlint to pre-commit
* Removed `pre_ticket` from pre-commit, as it conflicts with the conventional commit scheme
* Add `uv lock` to pre-commit
* Run pre-commit in CI, which replaces the `ruff check` and `ruff format` jobs
* Use the `astral-sh/setup-uv` action to get uv and python in CI
* Rename the "Test and Code Quality" workflow to the shorter "PR Checks", since the way Github displays checks in PRs makes longer workflow names less user-friendly (the actual check names get truncated quite quickly)
* Note that the CI job for commitlint remains, because running `pre-commit` manually after commit messages have been written doesn't cover `commitlint`
* Note that the CI jobs for mypy remain, because we only run mypy once in pre-commit, and depending upon whatever python version you've configured uv to use by default, we can't guarantee it ran on either 3.9 or 3.13 locally, so we just run both in CI