### PR TITLE
fix(packaging): if an SDK wheel is provided, ignore any uv.lock entry for the SDK

### DIFF
--- a/src/soar_sdk/cli/manifests/processors.py
+++ b/src/soar_sdk/cli/manifests/processors.py
@@ -17,7 +17,7 @@ class ManifestProcessor:
         self.manifest_path = manifest_path
         self.project_context = Path(project_context)
 
-    def build(self) -> AppMeta:
+    def build(self, exclude_sdk_wheel: bool = False) -> AppMeta:
         """
         Builds full AppMeta information including actions and other extra fields
         """
@@ -30,7 +30,9 @@ class ManifestProcessor:
         )
 
         uv_lock = self.load_app_uv_lock()
-        dependencies = uv_lock.build_package_list(app_meta.name)
+        dependencies = uv_lock.build_package_list(
+            app_meta.name, exclude_sdk=exclude_sdk_wheel
+        )
 
         app_meta.pip39_dependencies = uv_lock.resolve_python39_dependencies(
             dependencies

--- a/src/soar_sdk/cli/package/cli.py
+++ b/src/soar_sdk/cli/package/cli.py
@@ -84,15 +84,19 @@ def build(
     # Resolve the output path relative to the user's working directory, not the project context
     output_file = output_file.resolve()
     project_context = project_context.resolve()
+    sdk_wheel_provided = False
     if with_sdk_wheel_from:
         with_sdk_wheel_from = with_sdk_wheel_from.resolve()
+        sdk_wheel_provided = True
 
     console.print(Panel("[bold]Building SOAR App Package[/]", expand=False))
     console.print(f"[blue]App directory:[/] {project_context}")
     console.print(f"[blue]Output file:[/] {output_file}")
 
     with context_directory(project_context):
-        app_meta = ManifestProcessor("manifest.json", ".").build()
+        app_meta = ManifestProcessor("manifest.json", ".").build(
+            exclude_sdk_wheel=sdk_wheel_provided
+        )
         app_name = app_meta.name
         console.print(f"Generated manifest for app:[green] {app_name}[/]")
 

--- a/src/soar_sdk/meta/dependencies.py
+++ b/src/soar_sdk/meta/dependencies.py
@@ -211,7 +211,9 @@ class UvLock(BaseModel):
             raise LookupError(f"No package '{name}' found in uv.lock")
         return package
 
-    def build_package_list(self, root_package_name: str) -> list[UvPackage]:
+    def build_package_list(
+        self, root_package_name: str, exclude_sdk: bool = False
+    ) -> list[UvPackage]:
         packages = {root_package_name: self.get_package_entry(root_package_name)}
 
         new_packages_added = True
@@ -228,6 +230,9 @@ class UvLock(BaseModel):
 
         # Exclude the connector itself from the list of dependencies
         del packages[root_package_name]
+
+        if exclude_sdk and "soar-sdk" in packages:
+            del packages["soar-sdk"]
 
         # TODO: prune wheels that are provided with the platform (bs4, requests/urllib, etc.)
         # TODO: denylist for wheels that shouldn't be used in connectors (simplejson, django, etc.)

--- a/tests/meta/test_dependencies.py
+++ b/tests/meta/test_dependencies.py
@@ -1,4 +1,10 @@
-from soar_sdk.meta.dependencies import UvWheel, UvPackage, UvLock, DependencyWheel
+from soar_sdk.meta.dependencies import (
+    UvWheel,
+    UvPackage,
+    UvLock,
+    DependencyWheel,
+    UvDependency,
+)
 
 from typing import TypedDict, Optional
 
@@ -130,6 +136,38 @@ class TestUvLock:
 
         with pytest.raises(LookupError, match="No package 'requests' found in uv.lock"):
             lock.get_package_entry("requests")
+
+    def test_exclude_sdk(self):
+        lock = UvLock(
+            package=[
+                UvPackage(
+                    name="exampleapp",
+                    version="1.0.0",
+                    dependencies=[
+                        UvDependency(name="soar-sdk"),
+                        UvDependency(name="certifi"),
+                    ],
+                ),
+                UvPackage(name="soar-sdk", version="1.0.0"),
+                UvPackage(
+                    name="certifi",
+                    version="2025.1.31",
+                    wheels=[
+                        UvWheel(
+                            url="https://files.pythonhosted.org/packages/38/fc/bce832fd4fd99766c04d1ee0eead6b0ec6486fb100ae5e74c1d91292b982/certifi-2025.1.31-py3-none-any.whl",
+                            hash="sha256:ca78db4565a652026a4db2bcdf68f2fb589ea80d0be70e03929ed730746b84fe",
+                            size=166393,
+                        )
+                    ],
+                ),
+            ]
+        )
+
+        package_list = lock.build_package_list(
+            root_package_name="exampleapp", exclude_sdk=True
+        )
+
+        assert [p.name for p in package_list] == ["certifi"]
 
 
 class TestDependencyWheel:


### PR DESCRIPTION
This fixes an error encountered when building an app that isn't part of the SDK's uv workspace