### PR TITLE
fix(packaging): include "extras" groups when bundling dependencies

### DIFF
--- a/src/soar_sdk/meta/dependencies.py
+++ b/src/soar_sdk/meta/dependencies.py
@@ -124,6 +124,9 @@ class UvPackage(BaseModel):
     name: str
     version: str
     dependencies: list[UvDependency] = []
+    optional_dependencies: dict[str, list[UvDependency]] = Field(
+        default_factory=dict, alias="optional-dependencies"
+    )
     wheels: list[UvWheel] = []
 
     def _find_wheel(
@@ -246,7 +249,12 @@ class UvLock(BaseModel):
 
             scan_pass = list(packages.values())
             for package in scan_pass:
-                for dependency in package.dependencies:
+                package_dependencies = package.dependencies
+
+                for extra_group in package.optional_dependencies.values():
+                    package_dependencies += extra_group
+
+                for dependency in package_dependencies:
                     name = dependency.name
 
                     if name in DEPENDENCIES_TO_REJECT:

--- a/tests/example_app/app.json
+++ b/tests/example_app/app.json
@@ -112,7 +112,11 @@
     ],
     "pip39_dependencies": {
         "wheel": [
-
+            {
+                "module": "anyio",
+                "input_file": "wheels/python39/anyio-4.9.0-py3-none-any.whl",
+                "input_file_aarch64": "wheels/python39/anyio-4.9.0-py3-none-any.whl"
+            },
             {
                 "module": "boto3",
                 "input_file": "wheels/python39/boto3-1.38.3-py3-none-any.whl",
@@ -122,6 +126,41 @@
                 "module": "botocore",
                 "input_file": "wheels/python39/botocore-1.38.3-py3-none-any.whl",
                 "input_file_aarch64": "wheels/python39/botocore-1.38.3-py3-none-any.whl"
+            },
+            {
+                "module": "exceptiongroup",
+                "input_file": "wheels/python39/exceptiongroup-1.2.2-py3-none-any.whl",
+                "input_file_aarch64": "wheels/python39/exceptiongroup-1.2.2-py3-none-any.whl"
+            },
+            {
+                "module": "h11",
+                "input_file": "wheels/python39/h11-0.16.0-py3-none-any.whl",
+                "input_file_aarch64": "wheels/python39/h11-0.16.0-py3-none-any.whl"
+            },
+            {
+                "module": "h2",
+                "input_file": "wheels/python39/h2-4.2.0-py3-none-any.whl",
+                "input_file_aarch64": "wheels/python39/h2-4.2.0-py3-none-any.whl"
+            },
+            {
+                "module": "hpack",
+                "input_file": "wheels/python39/hpack-4.1.0-py3-none-any.whl",
+                "input_file_aarch64": "wheels/python39/hpack-4.1.0-py3-none-any.whl"
+            },
+            {
+                "module": "httpcore",
+                "input_file": "wheels/python39/httpcore-1.0.9-py3-none-any.whl",
+                "input_file_aarch64": "wheels/python39/httpcore-1.0.9-py3-none-any.whl"
+            },
+            {
+                "module": "httpx",
+                "input_file": "wheels/python39/httpx-0.28.1-py3-none-any.whl",
+                "input_file_aarch64": "wheels/python39/httpx-0.28.1-py3-none-any.whl"
+            },
+            {
+                "module": "hyperframe",
+                "input_file": "wheels/python39/hyperframe-6.1.0-py3-none-any.whl",
+                "input_file_aarch64": "wheels/python39/hyperframe-6.1.0-py3-none-any.whl"
             },
             {
                 "module": "jmespath",
@@ -137,12 +176,26 @@
                 "module": "s3transfer",
                 "input_file": "wheels/python39/s3transfer-0.12.0-py3-none-any.whl",
                 "input_file_aarch64": "wheels/python39/s3transfer-0.12.0-py3-none-any.whl"
+            },
+            {
+                "module": "sniffio",
+                "input_file": "wheels/python39/sniffio-1.3.1-py3-none-any.whl",
+                "input_file_aarch64": "wheels/python39/sniffio-1.3.1-py3-none-any.whl"
+            },
+            {
+                "module": "typing-extensions",
+                "input_file": "wheels/python39/typing_extensions-4.13.2-py3-none-any.whl",
+                "input_file_aarch64": "wheels/python39/typing_extensions-4.13.2-py3-none-any.whl"
             }
         ]
     },
     "pip313_dependencies": {
         "wheel": [
-
+            {
+                "module": "anyio",
+                "input_file": "wheels/python313/anyio-4.9.0-py3-none-any.whl",
+                "input_file_aarch64": "wheels/python313/anyio-4.9.0-py3-none-any.whl"
+            },
             {
                 "module": "boto3",
                 "input_file": "wheels/python313/boto3-1.38.3-py3-none-any.whl",
@@ -152,6 +205,41 @@
                 "module": "botocore",
                 "input_file": "wheels/python313/botocore-1.38.3-py3-none-any.whl",
                 "input_file_aarch64": "wheels/python313/botocore-1.38.3-py3-none-any.whl"
+            },
+            {
+                "module": "exceptiongroup",
+                "input_file": "wheels/python313/exceptiongroup-1.2.2-py3-none-any.whl",
+                "input_file_aarch64": "wheels/python313/exceptiongroup-1.2.2-py3-none-any.whl"
+            },
+            {
+                "module": "h11",
+                "input_file": "wheels/python313/h11-0.16.0-py3-none-any.whl",
+                "input_file_aarch64": "wheels/python313/h11-0.16.0-py3-none-any.whl"
+            },
+            {
+                "module": "h2",
+                "input_file": "wheels/python313/h2-4.2.0-py3-none-any.whl",
+                "input_file_aarch64": "wheels/python313/h2-4.2.0-py3-none-any.whl"
+            },
+            {
+                "module": "hpack",
+                "input_file": "wheels/python313/hpack-4.1.0-py3-none-any.whl",
+                "input_file_aarch64": "wheels/python313/hpack-4.1.0-py3-none-any.whl"
+            },
+            {
+                "module": "httpcore",
+                "input_file": "wheels/python313/httpcore-1.0.9-py3-none-any.whl",
+                "input_file_aarch64": "wheels/python313/httpcore-1.0.9-py3-none-any.whl"
+            },
+            {
+                "module": "httpx",
+                "input_file": "wheels/python313/httpx-0.28.1-py3-none-any.whl",
+                "input_file_aarch64": "wheels/python313/httpx-0.28.1-py3-none-any.whl"
+            },
+            {
+                "module": "hyperframe",
+                "input_file": "wheels/python313/hyperframe-6.1.0-py3-none-any.whl",
+                "input_file_aarch64": "wheels/python313/hyperframe-6.1.0-py3-none-any.whl"
             },
             {
                 "module": "jmespath",
@@ -167,6 +255,16 @@
                 "module": "s3transfer",
                 "input_file": "wheels/python313/s3transfer-0.12.0-py3-none-any.whl",
                 "input_file_aarch64": "wheels/python313/s3transfer-0.12.0-py3-none-any.whl"
+            },
+            {
+                "module": "sniffio",
+                "input_file": "wheels/python313/sniffio-1.3.1-py3-none-any.whl",
+                "input_file_aarch64": "wheels/python313/sniffio-1.3.1-py3-none-any.whl"
+            },
+            {
+                "module": "typing-extensions",
+                "input_file": "wheels/python313/typing_extensions-4.13.2-py3-none-any.whl",
+                "input_file_aarch64": "wheels/python313/typing_extensions-4.13.2-py3-none-any.whl"
             }
         ]
     }

--- a/tests/example_app/pyproject.toml
+++ b/tests/example_app/pyproject.toml
@@ -9,6 +9,7 @@ authors = [
 ]
 dependencies = [
     "boto3>=1.38.3",
+    "httpx[http2]>=0.28.1",
     "requests>=2.32.3",
     "soar-sdk",
 ]

--- a/tests/example_app/uv.lock
+++ b/tests/example_app/uv.lock
@@ -248,6 +248,7 @@ version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
     { name = "boto3", marker = "(python_full_version < '3.10' and platform_machine == 'arm64' and sys_platform == 'darwin') or (python_full_version >= '3.13' and platform_machine == 'arm64' and sys_platform == 'darwin') or (python_full_version < '3.10' and platform_machine == 'x86_64' and sys_platform == 'darwin') or (python_full_version >= '3.13' and platform_machine == 'x86_64' and sys_platform == 'darwin') or (python_full_version < '3.10' and platform_machine == 'aarch64' and sys_platform == 'linux') or (python_full_version >= '3.13' and platform_machine == 'aarch64' and sys_platform == 'linux') or (python_full_version < '3.10' and platform_machine == 'x86_64' and sys_platform == 'linux') or (python_full_version >= '3.13' and platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "httpx", extra = ["http2"], marker = "(python_full_version < '3.10' and platform_machine == 'arm64' and sys_platform == 'darwin') or (python_full_version >= '3.13' and platform_machine == 'arm64' and sys_platform == 'darwin') or (python_full_version < '3.10' and platform_machine == 'x86_64' and sys_platform == 'darwin') or (python_full_version >= '3.13' and platform_machine == 'x86_64' and sys_platform == 'darwin') or (python_full_version < '3.10' and platform_machine == 'aarch64' and sys_platform == 'linux') or (python_full_version >= '3.13' and platform_machine == 'aarch64' and sys_platform == 'linux') or (python_full_version < '3.10' and platform_machine == 'x86_64' and sys_platform == 'linux') or (python_full_version >= '3.13' and platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "requests", marker = "(python_full_version < '3.10' and platform_machine == 'arm64' and sys_platform == 'darwin') or (python_full_version >= '3.13' and platform_machine == 'arm64' and sys_platform == 'darwin') or (python_full_version < '3.10' and platform_machine == 'x86_64' and sys_platform == 'darwin') or (python_full_version >= '3.13' and platform_machine == 'x86_64' and sys_platform == 'darwin') or (python_full_version < '3.10' and platform_machine == 'aarch64' and sys_platform == 'linux') or (python_full_version >= '3.13' and platform_machine == 'aarch64' and sys_platform == 'linux') or (python_full_version < '3.10' and platform_machine == 'x86_64' and sys_platform == 'linux') or (python_full_version >= '3.13' and platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "soar-sdk", marker = "(python_full_version < '3.10' and platform_machine == 'arm64' and sys_platform == 'darwin') or (python_full_version >= '3.13' and platform_machine == 'arm64' and sys_platform == 'darwin') or (python_full_version < '3.10' and platform_machine == 'x86_64' and sys_platform == 'darwin') or (python_full_version >= '3.13' and platform_machine == 'x86_64' and sys_platform == 'darwin') or (python_full_version < '3.10' and platform_machine == 'aarch64' and sys_platform == 'linux') or (python_full_version >= '3.13' and platform_machine == 'aarch64' and sys_platform == 'linux') or (python_full_version < '3.10' and platform_machine == 'x86_64' and sys_platform == 'linux') or (python_full_version >= '3.13' and platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
@@ -266,6 +267,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "boto3", specifier = ">=1.38.3" },
+    { name = "httpx", extras = ["http2"], specifier = ">=0.28.1" },
     { name = "requests", specifier = ">=2.32.3" },
     { name = "soar-sdk", directory = "../../" },
 ]
@@ -309,6 +311,28 @@ wheels = [
 ]
 
 [[package]]
+name = "h2"
+version = "4.2.0"
+source = { registry = "https://pypi.python.org/simple" }
+dependencies = [
+    { name = "hpack", marker = "(python_full_version < '3.10' and platform_machine == 'arm64' and sys_platform == 'darwin') or (python_full_version >= '3.13' and platform_machine == 'arm64' and sys_platform == 'darwin') or (python_full_version < '3.10' and platform_machine == 'x86_64' and sys_platform == 'darwin') or (python_full_version >= '3.13' and platform_machine == 'x86_64' and sys_platform == 'darwin') or (python_full_version < '3.10' and platform_machine == 'aarch64' and sys_platform == 'linux') or (python_full_version >= '3.13' and platform_machine == 'aarch64' and sys_platform == 'linux') or (python_full_version < '3.10' and platform_machine == 'x86_64' and sys_platform == 'linux') or (python_full_version >= '3.13' and platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "hyperframe", marker = "(python_full_version < '3.10' and platform_machine == 'arm64' and sys_platform == 'darwin') or (python_full_version >= '3.13' and platform_machine == 'arm64' and sys_platform == 'darwin') or (python_full_version < '3.10' and platform_machine == 'x86_64' and sys_platform == 'darwin') or (python_full_version >= '3.13' and platform_machine == 'x86_64' and sys_platform == 'darwin') or (python_full_version < '3.10' and platform_machine == 'aarch64' and sys_platform == 'linux') or (python_full_version >= '3.13' and platform_machine == 'aarch64' and sys_platform == 'linux') or (python_full_version < '3.10' and platform_machine == 'x86_64' and sys_platform == 'linux') or (python_full_version >= '3.13' and platform_machine == 'x86_64' and sys_platform == 'linux')" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1b/38/d7f80fd13e6582fb8e0df8c9a653dcc02b03ca34f4d72f34869298c5baf8/h2-4.2.0.tar.gz", hash = "sha256:c8a52129695e88b1a0578d8d2cc6842bbd79128ac685463b887ee278126ad01f", size = 2150682, upload_time = "2025-02-02T07:43:51.815Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d0/9e/984486f2d0a0bd2b024bf4bc1c62688fcafa9e61991f041fb0e2def4a982/h2-4.2.0-py3-none-any.whl", hash = "sha256:479a53ad425bb29af087f3458a61d30780bc818e4ebcf01f0b536ba916462ed0", size = 60957, upload_time = "2025-02-01T11:02:26.481Z" },
+]
+
+[[package]]
+name = "hpack"
+version = "4.1.0"
+source = { registry = "https://pypi.python.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2c/48/71de9ed269fdae9c8057e5a4c0aa7402e8bb16f2c6e90b3aa53327b113f8/hpack-4.1.0.tar.gz", hash = "sha256:ec5eca154f7056aa06f196a557655c5b009b382873ac8d1e66e79e87535f1dca", size = 51276, upload_time = "2025-01-22T21:44:58.347Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/07/c6/80c95b1b2b94682a72cbdbfb85b81ae2daffa4291fbfa1b1464502ede10d/hpack-4.1.0-py3-none-any.whl", hash = "sha256:157ac792668d995c657d93111f46b4535ed114f0c9c8d672271bbec7eae1b496", size = 34357, upload_time = "2025-01-22T21:44:56.92Z" },
+]
+
+[[package]]
 name = "httpcore"
 version = "1.0.9"
 source = { registry = "https://pypi.python.org/simple" }
@@ -336,6 +360,11 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload_time = "2024-12-06T15:37:21.509Z" },
 ]
 
+[package.optional-dependencies]
+http2 = [
+    { name = "h2", marker = "(python_full_version < '3.10' and platform_machine == 'arm64' and sys_platform == 'darwin') or (python_full_version >= '3.13' and platform_machine == 'arm64' and sys_platform == 'darwin') or (python_full_version < '3.10' and platform_machine == 'x86_64' and sys_platform == 'darwin') or (python_full_version >= '3.13' and platform_machine == 'x86_64' and sys_platform == 'darwin') or (python_full_version < '3.10' and platform_machine == 'aarch64' and sys_platform == 'linux') or (python_full_version >= '3.13' and platform_machine == 'aarch64' and sys_platform == 'linux') or (python_full_version < '3.10' and platform_machine == 'x86_64' and sys_platform == 'linux') or (python_full_version >= '3.13' and platform_machine == 'x86_64' and sys_platform == 'linux')" },
+]
+
 [[package]]
 name = "humanize"
 version = "4.12.2"
@@ -343,6 +372,15 @@ source = { registry = "https://pypi.python.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e0/84/ae8e64a6ffe3291105e9688f4e28fa65eba7924e0fe6053d85ca00556385/humanize-4.12.2.tar.gz", hash = "sha256:ce0715740e9caacc982bb89098182cf8ded3552693a433311c6a4ce6f4e12a2c", size = 80871, upload_time = "2025-03-24T17:12:39.167Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/55/c7/6f89082f619c76165feb633446bd0fee32b0e0cbad00d22480e5aea26ade/humanize-4.12.2-py3-none-any.whl", hash = "sha256:e4e44dced598b7e03487f3b1c6fd5b1146c30ea55a110e71d5d4bca3e094259e", size = 128305, upload_time = "2025-03-24T17:12:37.059Z" },
+]
+
+[[package]]
+name = "hyperframe"
+version = "6.1.0"
+source = { registry = "https://pypi.python.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/02/e7/94f8232d4a74cc99514c13a9f995811485a6903d48e5d952771ef6322e30/hyperframe-6.1.0.tar.gz", hash = "sha256:f630908a00854a7adeabd6382b43923a4c4cd4b821fcb527e6ab9e15382a3b08", size = 26566, upload_time = "2025-01-22T21:41:49.302Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/48/30/47d0bf6072f7252e6521f3447ccfa40b421b6824517f82854703d0f5a98b/hyperframe-6.1.0-py3-none-any.whl", hash = "sha256:b03380493a519fce58ea5af42e4a42317bf9bd425596f7a0835ffce80f1a42e5", size = 13007, upload_time = "2025-01-22T21:41:47.295Z" },
 ]
 
 [[package]]
@@ -799,7 +837,7 @@ wheels = [
 
 [[package]]
 name = "soar-sdk"
-version = "1.0.0a19"
+version = "1.0.0a21"
 source = { directory = "../../" }
 dependencies = [
     { name = "beautifulsoup4", marker = "(python_full_version < '3.10' and platform_machine == 'arm64' and sys_platform == 'darwin') or (python_full_version >= '3.13' and platform_machine == 'arm64' and sys_platform == 'darwin') or (python_full_version < '3.10' and platform_machine == 'x86_64' and sys_platform == 'darwin') or (python_full_version >= '3.13' and platform_machine == 'x86_64' and sys_platform == 'darwin') or (python_full_version < '3.10' and platform_machine == 'aarch64' and sys_platform == 'linux') or (python_full_version >= '3.13' and platform_machine == 'aarch64' and sys_platform == 'linux') or (python_full_version < '3.10' and platform_machine == 'x86_64' and sys_platform == 'linux') or (python_full_version >= '3.13' and platform_machine == 'x86_64' and sys_platform == 'linux')" },


### PR DESCRIPTION
This is required when importing certain dependencies, such as `httpx[http2]` -- `httpx` is the dependency, `http2` is an extras group which installs other packages needed for HTTP/2 support.