### PR TITLE
feat: Structured exceptions

### DIFF
--- a/src/soar_sdk/abstract.py
+++ b/src/soar_sdk/abstract.py
@@ -80,3 +80,7 @@ class SOARClient(ABC):
         dump_object: Union[str, list, dict, ActionResult, Exception] = "",
     ) -> None:
         pass
+
+    @abstractmethod
+    def add_exception(self, exception: Exception) -> None:
+        pass

--- a/src/soar_sdk/adapters.py
+++ b/src/soar_sdk/adapters.py
@@ -63,3 +63,6 @@ class LegacyConnectorAdapter(SOARClient):
         dump_object: Union[str, list, dict, ActionResult, Exception] = "",
     ) -> None:
         self.connector.error_print(tag, dump_object)
+
+    def add_exception(self, exception: Exception) -> None:
+        self.connector._BaseConnector__conn_result.add_exception(exception)

--- a/src/soar_sdk/app.py
+++ b/src/soar_sdk/app.py
@@ -152,11 +152,11 @@ class App:
                     )
                 except Exception as e:
                     client.add_exception(e)
-                    tb_str = "".join(
+                    traceback_str = "".join(
                         traceback.format_exception(type(e), e, e.__traceback__)
                     )
                     return self._adapt_action_result(
-                        ActionResult(status=False, message=tb_str), client
+                        ActionResult(status=False, message=traceback_str), client
                     )
 
                 return self._adapt_action_result(result, client)
@@ -232,11 +232,11 @@ class App:
                     )
                 except Exception as e:
                     client.add_exception(e)
-                    tb_str = "".join(
+                    traceback_str = "".join(
                         traceback.format_exception(type(e), e, e.__traceback__)
                     )
                     return self._adapt_action_result(
-                        ActionResult(status=False, message=tb_str), client
+                        ActionResult(status=False, message=traceback_str), client
                     )
 
                 return self._adapt_action_result(

--- a/src/soar_sdk/connector.py
+++ b/src/soar_sdk/connector.py
@@ -5,7 +5,6 @@ from pydantic import ValidationError
 from soar_sdk.input_spec import InputSpecification
 from soar_sdk.shims.phantom.action_result import ActionResult as PhantomActionResult
 from soar_sdk.shims.phantom.base_connector import BaseConnector
-
 from .abstract import SOARClient
 
 if TYPE_CHECKING:

--- a/src/soar_sdk/connector.py
+++ b/src/soar_sdk/connector.py
@@ -5,6 +5,7 @@ from pydantic import ValidationError
 from soar_sdk.input_spec import InputSpecification
 from soar_sdk.shims.phantom.action_result import ActionResult as PhantomActionResult
 from soar_sdk.shims.phantom.base_connector import BaseConnector
+
 from .abstract import SOARClient
 
 if TYPE_CHECKING:
@@ -108,3 +109,6 @@ class AppConnector(BaseConnector, SOARClient):
         dump_object: Union[str, list, dict, PhantomActionResult, Exception] = "",
     ) -> None:
         self.error_print(tag, dump_object)
+
+    def add_exception(self, exception: Exception) -> None:
+        self._BaseConnector__conn_result.add_exception(exception)

--- a/src/soar_sdk/exceptions.py
+++ b/src/soar_sdk/exceptions.py
@@ -1,0 +1,37 @@
+from typing import Optional
+
+
+class ActionFailure(Exception):
+    """Exception raised when an action fails to execute successfully."""
+
+    def __init__(self, message: str, action_name: Optional[str] = None) -> None:
+        self.message = message
+        self.action_name = action_name
+        super().__init__(self.message)
+
+    def set_action_name(self, action_name: str) -> None:
+        """Set the name of the action that failed."""
+        self.action_name = action_name
+
+    def __str__(self) -> str:
+        """Return a formatted error message."""
+        return (
+            f"Action failure in {self.action_name}: {self.message}"
+            if self.action_name
+            else f"Action failure: {self.message}"
+        )
+
+
+class AssetMisconfiguration(ActionFailure):
+    """Exception raised when an asset is misconfigured."""
+
+    def __str__(self) -> str:
+        """Return a formatted error message."""
+        return (
+            f"Asset misconfiguration in {self.action_name}: {self.message}"
+            if self.action_name
+            else f"Asset misconfiguration: {self.message}"
+        )
+
+
+__all__ = ["ActionFailure", "AssetMisconfiguration"]

--- a/src/soar_sdk/shims/phantom/base_connector.py
+++ b/src/soar_sdk/shims/phantom/base_connector.py
@@ -12,6 +12,7 @@ if TYPE_CHECKING or not _soar_is_available:
     import abc
 
     from soar_sdk.shims.phantom.action_result import ActionResult
+    from soar_sdk.shims.phantom.connector_result import ConnectorResult
 
     from typing import Union, Any
     from contextlib import suppress
@@ -19,6 +20,8 @@ if TYPE_CHECKING or not _soar_is_available:
     class BaseConnector:  # type: ignore[no-redef]
         def __init__(self) -> None:
             self.action_results: list[ActionResult] = []
+            self.__conn_result: ConnectorResult
+            self.__conn_result = ConnectorResult()
 
         @staticmethod
         def _get_phantom_base_url() -> str:

--- a/src/soar_sdk/shims/phantom/connector_result.py
+++ b/src/soar_sdk/shims/phantom/connector_result.py
@@ -1,0 +1,25 @@
+try:
+    from phantom.connector_result import ConnectorResult
+
+    _soar_is_available = True
+except ImportError:
+    _soar_is_available = False
+
+from typing import TYPE_CHECKING
+
+
+if TYPE_CHECKING or not _soar_is_available:
+    import traceback
+
+    class ConnectorResult:  # type: ignore[no-redef]
+        def __init__(self) -> None:
+            self.__exception_occured = False
+
+        def add_exception(self, exception: Exception) -> bool:
+            self.__exception_occured = True
+            traceback.print_exception(
+                type(exception), exception, exception.__traceback__
+            )
+
+
+__all__ = ["ConnectorResult"]

--- a/tests/test_adapters.py
+++ b/tests/test_adapters.py
@@ -18,6 +18,7 @@ def test_legacy_connector_adapter_delegates_method_calls():
     adapter.save_progress(mock.Mock())
     adapter.debug(mock.Mock())
     adapter.error(mock.Mock())
+    adapter.add_exception(mock.Mock())
 
     for method_name in adapter.connector.mocked_methods:
         mocked_method = getattr(adapter.connector, method_name)

--- a/tests/test_app_action.py
+++ b/tests/test_app_action.py
@@ -7,6 +7,7 @@ from soar_sdk.app import App
 from soar_sdk.params import Param, Params
 from soar_sdk.action_results import ActionOutput
 from tests.stubs import SampleActionParams, SampleNestedOutput, SampleOutput
+from soar_sdk.exceptions import ActionFailure
 
 
 class SampleParams(Params):
@@ -239,3 +240,25 @@ def test_action_decoration_passing_output_type_as_argument(simple_app):
         assert True
 
     foo(SampleActionParams())
+
+
+def test_action_failure_raised(simple_app: App):
+    @simple_app.action()
+    def action_function(params: Params, client: SOARClient) -> ActionOutput:
+        raise ActionFailure("Action failed")
+
+    client_mock = mock.Mock()
+
+    result = action_function(Params(), client=client_mock)
+    assert not result
+    assert client_mock.add_result.call_count == 1
+
+
+def test_other_failure_raised(simple_app: App, app_connector):
+    @simple_app.action()
+    def action_function(params: Params, client: SOARClient) -> ActionOutput:
+        raise ValueError("Value error occurred")
+
+    result = action_function(Params(), client=app_connector)
+
+    assert not result

--- a/tests/test_test_connectivity.py
+++ b/tests/test_test_connectivity.py
@@ -69,8 +69,10 @@ def test_connectivity_raises_with_no_type_hint(simple_app):
     def test_connectivity(client: SOARClient):
         return ActionOutput(bool=True)
 
-    with pytest.raises(RuntimeError):
-        test_connectivity()
+    client_mock = mock.Mock()
+    result = test_connectivity(client=client_mock)
+    assert not result
+    assert client_mock.add_result.call_count == 1
 
 
 def test_connectivity_bubbles_up_errors(simple_app):


### PR DESCRIPTION
- Swallows ActionFailure and AssetMisconfiguration exceptions
- For every other exception add_exception is called to set exception_occured in the db and an ActionResult with the traceback is sent to the client

Raise AssetConfig error in test connectivity:
<img width="860" alt="Screenshot 2025-05-07 at 3 14 28 PM" src="https://github.com/user-attachments/assets/0f1f951b-87ef-4600-a90a-eb4450a90c19" />

Raise ActionFailure:
<img width="1351" alt="Screenshot 2025-05-07 at 3 30 59 PM" src="https://github.com/user-attachments/assets/2bd617f8-9469-40c3-91ae-d4b6e3e5dbab" />

Raise ValueError:
<img width="1394" alt="Screenshot 2025-05-07 at 5 46 16 PM" src="https://github.com/user-attachments/assets/64e3d267-5318-4d54-8e2e-2eca9ad991af" />

![Screenshot 2025-05-07 at 3 20 15 PM](https://github.com/user-attachments/assets/b1ad4491-9410-49b9-98c2-d3a1f6847af9)

List of actions:
<img width="1378" alt="Screenshot 2025-05-07 at 5 46 42 PM" src="https://github.com/user-attachments/assets/3657996e-61d4-4107-bdd5-e6b721fad0ad" />
