### PR TITLE
feat: move metadata fields into app constructor

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ class Asset(BaseAsset):
     api_key: str = AssetField(sensitive=True, description="API key for authentication")
 
 
-app = App(asset_cls=Asset)
+app = App(name="test_app", asset_cls=Asset, appid="1e1618e7-2f70-4fc0-916a-f96facc2d2e4", app_type="sandbox", logo="logo.svg", logo_dark="logo_dark.svg", product_vendor="Splunk", product_name="Example App", publisher="Splunk")
 
 
 @app.test_connectivity()

--- a/app_templates/basic_app/pyproject.toml
+++ b/app_templates/basic_app/pyproject.toml
@@ -2,6 +2,7 @@
 name = "basic_app"
 version = "0.1.0"
 description = "This is the basic example SOAR app"
+main_module = "src.app:app"
 license = "Copyright"
 readme = "README.md"
 requires-python = ">=3.9, <3.14"
@@ -20,18 +21,3 @@ dev = [
     "pytest-watch>=4.2.0,<5",
     "ruff>=0.11.6,<1",
 ]
-
-[tool.soar.app]
-appid = "1e1618e7-2f70-4fc0-916a-f96facc2d2e4"
-type = "sandbox"
-product_vendor = "Splunk"
-logo = "logo.svg"
-logo_dark = "logo_dark.svg"
-product_name = "Example App"
-python_version = "3"
-product_version_regex = ".*"
-publisher = "Splunk"
-min_phantom_version = "6.2.2.134"
-app_wizard_version = "1.0.0"
-fips_compliant = false
-main_module = "src.app:app"

--- a/app_templates/basic_app/src/app.py
+++ b/app_templates/basic_app/src/app.py
@@ -4,7 +4,16 @@ from soar_sdk.app import App
 from soar_sdk.params import Params
 from soar_sdk.action_results import ActionOutput
 
-app = App(name="basic_app")
+app = App(
+    name="basic_app",
+    appid="1e1618e7-2f70-4fc0-916a-f96facc2d2e4",
+    app_type="sandbox",
+    product_vendor="Splunk",
+    logo="logo.svg",
+    logo_dark="logo_dark.svg",
+    product_name="Example App",
+    publisher="Splunk",
+)
 
 
 @app.action(action_type="test")

--- a/src/soar_sdk/app.py
+++ b/src/soar_sdk/app.py
@@ -42,10 +42,8 @@ class App:
         product_name: str,
         publisher: str,
         appid: str,
-        python_version: str = "3",
-        product_version_regex: str = ".*",
-        min_phantom_version: str = "6.3",
-        app_wizard_version: str = "1.0.0",
+        python_version: list[str] = ["3.9", "3.13"],  # noqa: B006
+        min_phantom_version: str = "6.4.0",
         fips_compliant: bool = False,
         asset_cls: type[BaseAsset] = BaseAsset,
         legacy_connector_class: Optional[type[BaseConnector]] = None,
@@ -65,9 +63,7 @@ class App:
             "product_name": product_name,
             "publisher": publisher,
             "python_version": python_version,
-            "product_version_regex": product_version_regex,
             "min_phantom_version": min_phantom_version,
-            "app_wizard_version": app_wizard_version,
             "fips_compliant": fips_compliant,
             "appid": appid,
         }

--- a/src/soar_sdk/app.py
+++ b/src/soar_sdk/app.py
@@ -19,6 +19,15 @@ from soar_sdk.types import Action, action_protocol
 from soar_sdk.logging import getLogger
 from soar_sdk.exceptions import ActionFailure, AssetMisconfiguration
 import traceback
+import uuid
+
+
+def is_valid_uuid(value: str) -> bool:
+    """Validates if a string is a valid UUID"""
+    try:
+        return str(uuid.UUID(value)).lower() == value.lower()
+    except ValueError:
+        return False
 
 
 class App:
@@ -26,13 +35,42 @@ class App:
         self,
         *,
         name: str,
+        app_type: str,
+        logo: str,
+        logo_dark: str,
+        product_vendor: str,
+        product_name: str,
+        publisher: str,
+        appid: str,
+        python_version: str = "3",
+        product_version_regex: str = ".*",
+        min_phantom_version: str = "6.3",
+        app_wizard_version: str = "1.0.0",
+        fips_compliant: bool = False,
         asset_cls: type[BaseAsset] = BaseAsset,
         legacy_connector_class: Optional[type[BaseConnector]] = None,
     ) -> None:
-        self.app_name = name
         self.asset_cls = asset_cls
         self._raw_asset_config: dict[str, Any] = {}
         self.__logger = getLogger()
+        if not is_valid_uuid(appid):
+            raise ValueError(f"Appid is not a valid uuid: {appid}")
+
+        self.app_meta_info = {
+            "name": name,
+            "type": app_type,
+            "logo": logo,
+            "logo_dark": logo_dark,
+            "product_vendor": product_vendor,
+            "product_name": product_name,
+            "publisher": publisher,
+            "python_version": python_version,
+            "product_version_regex": product_version_regex,
+            "min_phantom_version": min_phantom_version,
+            "app_wizard_version": app_wizard_version,
+            "fips_compliant": fips_compliant,
+            "appid": appid,
+        }
 
         self.actions_provider = ActionsProvider(legacy_connector_class)
 

--- a/src/soar_sdk/cli/manifests/processors.py
+++ b/src/soar_sdk/cli/manifests/processors.py
@@ -23,12 +23,13 @@ class ManifestProcessor:
         """
         app_meta: AppMeta = self.load_toml_app_meta()
         app = self.import_app_instance(app_meta)
-        app_meta.name = app.app_name
         app_meta.configuration = app.asset_cls.to_json_schema()
         app_meta.actions = app.actions_provider.get_actions_meta_list()
         app_meta.utctime_updated = datetime.now(timezone.utc).strftime(
             "%Y-%m-%dT%H:%M:%S.%fZ"
         )
+        for field, value in app.app_meta_info.items():
+            setattr(app_meta, field, value)
 
         uv_lock = self.load_app_uv_lock()
         dependencies = uv_lock.build_package_list(app_meta.project_name)

--- a/src/soar_sdk/meta/adapters.py
+++ b/src/soar_sdk/meta/adapters.py
@@ -9,7 +9,6 @@ class TOMLDataAdapter:
         with open(filepath) as f:
             toml_data = toml.load(f)
 
-        soar_app_data = toml_data.get("tool", {}).get("soar", {}).get("app", {})
         uv_app_data = toml_data.get("project", {})
         project_name = uv_app_data.get("name")
         package_name = (
@@ -25,6 +24,6 @@ class TOMLDataAdapter:
                 license=uv_app_data.get("license"),
                 package_name=package_name,
                 project_name=project_name,
-                **soar_app_data,
+                main_module=uv_app_data.get("main_module"),
             )
         )

--- a/src/soar_sdk/meta/app.py
+++ b/src/soar_sdk/meta/app.py
@@ -19,11 +19,10 @@ class AppMeta(BaseModel):
     logo: str = ""
     logo_dark: str = ""
     product_name: str = ""
-    python_version: str = "3"
+    python_version: list[str] = ["3.9", "3.13"]
     product_version_regex: str = ".*"
     publisher: str = ""
     utctime_updated: str = ""
-    app_wizard_version: str = ""
     fips_compliant: bool = False
 
     configuration: dict = Field(default_factory=dict)

--- a/src/soar_sdk/meta/app.py
+++ b/src/soar_sdk/meta/app.py
@@ -7,12 +7,12 @@ from .dependencies import DependencyList
 class AppMeta(BaseModel):
     name: str = ""
     description: str
-    appid: str
-    type: str
-    product_vendor: str
+    appid: str = "1e1618e7-2f70-4fc0-916a-f96facc2d2e4"  # placeholder value to pass inital validation
+    type: str = ""
+    product_vendor: str = ""
     app_version: str
     license: str
-    min_phantom_version: str
+    min_phantom_version: str = ""
     package_name: str
     project_name: str = Field(exclude=True)
     main_module: str = "src/app.py:app"  # TODO: Some validation would be nice

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,10 +13,21 @@ from soar_sdk.meta.dependencies import UvWheel
 from tests.stubs import SampleActionParams
 from pathlib import Path
 
+APP_ID = "9b388c08-67de-4ca4-817f-26f8fb7cbf55"
+
 
 @pytest.fixture
 def example_app() -> App:
-    app = App(name="example_app")
+    app = App(
+        name="example_app",
+        appid=APP_ID,
+        app_type="sandbox",
+        logo="logo.svg",
+        logo_dark="logo_dark.svg",
+        product_vendor="Splunk",
+        product_name="Example App",
+        publisher="Splunk",
+    )
     app.actions_provider.soar_client._load_app_json = mock.Mock(return_value=True)
     app.actions_provider.soar_client.get_state_dir = mock.Mock(return_value="/tmp/")
     app.actions_provider.soar_client._load_app_json = mock.Mock(return_value=True)
@@ -39,13 +50,31 @@ def default_args():
 
 @pytest.fixture
 def simple_app() -> App:
-    return App(name="simple_app")
+    return App(
+        name="simple_app",
+        appid=APP_ID,
+        app_type="sandbox",
+        logo="logo.svg",
+        logo_dark="logo_dark.svg",
+        product_vendor="Splunk",
+        product_name="Example App",
+        publisher="Splunk",
+    )
 
 
 @pytest.fixture
 def app_with_action() -> App:
     """Create an app with a pre-configured 'test_action' for testing."""
-    app = App(name="test_app")
+    app = App(
+        name="test_app",
+        appid=APP_ID,
+        app_type="sandbox",
+        logo="logo.svg",
+        logo_dark="logo_dark.svg",
+        product_vendor="Splunk",
+        product_name="Example App",
+        publisher="Splunk",
+    )
 
     @app.action(
         name="Test Action",
@@ -63,7 +92,16 @@ def app_with_action() -> App:
 @pytest.fixture
 def app_with_asset_action() -> App:
     """Create an app with a pre-configured action that requires an asset."""
-    app = App(name="test_app_with_asset")
+    app = App(
+        name="test_app_with_asset",
+        appid=APP_ID,
+        app_type="sandbox",
+        logo="logo.svg",
+        logo_dark="logo_dark.svg",
+        product_vendor="Splunk",
+        product_name="Example App",
+        publisher="Splunk",
+    )
 
     @app.action(
         name="Test Action With Asset",
@@ -82,7 +120,17 @@ def app_with_simple_asset() -> App:
     class Asset(BaseAsset):
         base_url: str
 
-    return App(asset_cls=Asset, name="app_with_asset")
+    return App(
+        asset_cls=Asset,
+        name="app_with_asset",
+        appid=APP_ID,
+        app_type="sandbox",
+        logo="logo.svg",
+        logo_dark="logo_dark.svg",
+        product_vendor="Splunk",
+        product_name="Example App",
+        publisher="Splunk",
+    )
 
 
 @pytest.fixture

--- a/tests/example_app/app.json
+++ b/tests/example_app/app.json
@@ -12,11 +12,10 @@
     "logo": "logo.svg",
     "logo_dark": "logo_dark.svg",
     "product_name": "Example App",
-    "python_version": "3",
+    "python_version": ["3.9", "3.13"],
     "product_version_regex": ".*",
     "publisher": "Splunk Inc.",
     "utctime_updated": "2025-04-17T12:00:00.000000Z",
-    "app_wizard_version": "1.0.0",
     "fips_compliant": false,
     "configuration": {
         "base_url": {

--- a/tests/example_app/pyproject.toml
+++ b/tests/example_app/pyproject.toml
@@ -3,6 +3,7 @@ name = "exampleapp"
 version = "0.1.0"
 description = "This is the basic example SOAR app"
 license = "Copyright (c) Splunk Inc., 2025"
+main_module = "src.app:app"
 readme = "README.md"
 requires-python = ">=3.9, <3.14"
 authors = [
@@ -47,18 +48,3 @@ required-environments = [
     "sys_platform == 'linux' and platform_machine == 'x86_64' and python_version == '3.9'",
     "sys_platform == 'linux' and platform_machine == 'x86_64' and python_version == '3.13'",
 ]
-
-[tool.soar.app]
-appid = "9b388c08-67de-4ca4-817f-26f8fb7cbf55"
-type = "sandbox"
-product_vendor = "Splunk Inc."
-logo = "logo.svg"
-logo_dark = "logo_dark.svg"
-product_name = "Example App"
-python_version = "3"
-product_version_regex = ".*"
-publisher = "Splunk Inc."
-min_phantom_version = "6.2.2.134"
-app_wizard_version = "1.0.0"
-fips_compliant = false
-main_module = "src.app:app"

--- a/tests/example_app/src/app.py
+++ b/tests/example_app/src/app.py
@@ -19,7 +19,18 @@ class Asset(BaseAsset):
     )
 
 
-app = App(asset_cls=Asset, name="example_app")
+app = App(
+    asset_cls=Asset,
+    name="example_app",
+    appid="9b388c08-67de-4ca4-817f-26f8fb7cbf55",
+    app_type="sandbox",
+    product_vendor="Splunk Inc.",
+    logo="logo.svg",
+    logo_dark="logo_dark.svg",
+    product_name="Example App",
+    publisher="Splunk Inc.",
+    min_phantom_version="6.2.2.134",
+)
 
 
 @app.test_connectivity()

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -4,6 +4,7 @@ from soar_sdk.action_results import ActionOutput
 from soar_sdk.app import App
 from soar_sdk.input_spec import InputSpecification
 from soar_sdk.params import Params
+import pytest
 
 
 def test_app_run(example_app):
@@ -42,3 +43,32 @@ def test_app_asset(app_with_simple_asset: App):
     assert asset.base_url == "https://example.com"
     assert hasattr(app_with_simple_asset, "_asset")
     assert app_with_simple_asset.asset is asset
+
+
+def test_appid_not_uuid():
+    with pytest.raises(ValueError, match="Appid is not a valid uuid: invalid"):
+        App(
+            name="example_app",
+            appid="invalid",
+            app_type="sandbox",
+            product_vendor="Splunk Inc.",
+            logo="logo.svg",
+            logo_dark="logo_dark.svg",
+            product_name="Example App",
+            publisher="Splunk Inc.",
+        )
+
+    with pytest.raises(
+        ValueError,
+        match="Appid is not a valid uuid: 00000000000000000000000000000000",
+    ):
+        App(
+            name="example_app",
+            appid="00000000000000000000000000000000",
+            app_type="sandbox",
+            product_vendor="Splunk Inc.",
+            logo="logo.svg",
+            logo_dark="logo_dark.svg",
+            product_name="Example App",
+            publisher="Splunk Inc.",
+        )


### PR DESCRIPTION
- All fields previously in [talos.soar.app] are not in the constructor, except for main_module which is now in [project]. This is because main_module is needed to load the app_instance. 