### PR TITLE
feat: authenticated soar client

### DIFF
--- a/src/soar_sdk/abstract.py
+++ b/src/soar_sdk/abstract.py
@@ -17,9 +17,20 @@ class SOARClient(ABC):
     ingestion_state: dict
     auth_state: dict
     asset_cache: dict
+    @property
+    @abstractmethod
+    def client(self) -> Any:
+        """
+        Subclasses must define the client property.
+        """
+        pass
 
     @abstractmethod
     def get_soar_base_url(self) -> str:
+        pass
+
+    @abstractmethod
+    def authenticate_soar_client(self, input_data: InputSpecification) -> None:
         pass
 
     @abstractmethod

--- a/src/soar_sdk/abstract.py
+++ b/src/soar_sdk/abstract.py
@@ -4,6 +4,7 @@ from typing import Any, Optional, Union
 from soar_sdk.input_spec import InputSpecification
 from soar_sdk.shims.phantom.action_result import ActionResult as PhantomActionResult
 from soar_sdk.action_results import ActionResult
+import httpx
 
 
 class SOARClient(ABC):
@@ -17,9 +18,10 @@ class SOARClient(ABC):
     ingestion_state: dict
     auth_state: dict
     asset_cache: dict
+
     @property
     @abstractmethod
-    def client(self) -> Any:
+    def client(self) -> httpx.Client:
         """
         Subclasses must define the client property.
         """

--- a/src/soar_sdk/adapters.py
+++ b/src/soar_sdk/adapters.py
@@ -6,6 +6,7 @@ from soar_sdk.shims.phantom.base_connector import BaseConnector
 from soar_sdk.action_results import ActionResult
 
 from .abstract import SOARClient
+import httpx
 
 
 class LegacyConnectorAdapter(SOARClient):
@@ -25,11 +26,13 @@ class LegacyConnectorAdapter(SOARClient):
         self.connector.handle_action(param)
 
     @property
-    def client(self) -> Any:
+    def client(self) -> httpx.Client:
         """
         Returns the client object.
         """
-        return self.connector.client
+        raise NotImplementedError(
+            "The soar client is not supported in legacy connectors."
+        )
 
     def authenticate_soar_client(self, input_data: InputSpecification) -> None:
         """

--- a/src/soar_sdk/adapters.py
+++ b/src/soar_sdk/adapters.py
@@ -24,6 +24,19 @@ class LegacyConnectorAdapter(SOARClient):
     def handle_action(self, param: dict[str, Any]) -> None:
         self.connector.handle_action(param)
 
+    @property
+    def client(self) -> Any:
+        """
+        Returns the client object.
+        """
+        return self.connector.client
+
+    def authenticate_soar_client(self, input_data: InputSpecification) -> None:
+        """
+        Not implemented in the legacy connector.
+        """
+        pass
+
     def handle(
         self,
         input_data: InputSpecification,

--- a/src/soar_sdk/app.py
+++ b/src/soar_sdk/app.py
@@ -94,6 +94,7 @@ class App:
         input_data = InputSpecification.parse_obj(json.loads(raw_input_data))
         self._raw_asset_config = input_data.config.get_asset_config()
         self.__logger.handler.set_handle(handle)
+        self.actions_provider.soar_client.authenticate_soar_client(input_data)
         return self.actions_provider.handle(input_data, handle=handle)
 
     __call__ = handle  # the app instance can be called for ease of use by spawn3

--- a/src/soar_sdk/app_cli_runner.py
+++ b/src/soar_sdk/app_cli_runner.py
@@ -6,7 +6,6 @@ from pprint import pprint
 import typing
 from typing import Optional, Any
 
-
 from soar_sdk.input_spec import ActionParameter, AppConfig, InputSpecification
 from soar_sdk.types import Action
 
@@ -25,6 +24,13 @@ class AppCliRunner:
 
     def parse_args(self, argv: Optional[list[str]] = None) -> argparse.Namespace:
         root_parser = argparse.ArgumentParser()
+        root_parser.add_argument("--soar-url", type=str, help="SOAR URL to connect to")
+        root_parser.add_argument(
+            "--username", type=str, help="Username to connect to SOAR instance"
+        )
+        root_parser.add_argument(
+            "--password", type=str, help="Password to connect to SOAR instance"
+        )
 
         subparsers = root_parser.add_subparsers(dest="action", title="Actions")
         subparsers.required = True
@@ -99,6 +105,30 @@ class AppCliRunner:
             ),
             parameters=parameter_list,
         )
+
+        if args.soar_url and args.username and args.password:
+            # This is an all or nothing. If any of these are missing, we don't set them.
+            soar_url = (
+                f"https://{args.soar_url}"
+                if not args.soar_url.startswith(("http://", "https://"))
+                else args.soar_url
+            )
+
+            input_data.environment_variables = {
+                "PHANTOM_BASE_URL": {
+                    "type": "string",
+                    "value": soar_url,
+                },
+                "PHANTOM_USER": {
+                    "type": "string",
+                    "value": args.username,
+                },
+                "PHANTOM_PASSWORD": {
+                    "type": "string",
+                    "value": args.password,
+                },
+            }
+
         args.raw_input_data = input_data.json()
         return args
 

--- a/src/soar_sdk/connector.py
+++ b/src/soar_sdk/connector.py
@@ -67,7 +67,6 @@ class AppConnector(BaseConnector, SOARClient):
                     verify=False,  # noqa: S501
                 )
                 self.__login()
-                print("hereeeee")
                 session_id = self.get_session_id(
                     input_data.soar_auth.username,
                     input_data.soar_auth.password,
@@ -304,7 +303,6 @@ class AppConnector(BaseConnector, SOARClient):
             for artifact in artifacts:
                 artifact["container_id"] = next_container_id
                 self._save_artifact(artifact)
-
             self.__containers[next_container_id] = container
             return (True, "Container added successfully", next_container_id)
 

--- a/src/soar_sdk/exceptions.py
+++ b/src/soar_sdk/exceptions.py
@@ -34,4 +34,16 @@ class AssetMisconfiguration(ActionFailure):
         )
 
 
+class SoarAPIError(ActionFailure):
+    """Exception raised when there is an error with the SOAR REST API."""
+
+    def __str__(self) -> str:
+        """Return a formatted error message."""
+        return (
+            f"SOAR REST API error in {self.action_name}: {self.message}"
+            if self.action_name
+            else f"SOAR REST API error: {self.message}"
+        )
+
+
 __all__ = ["ActionFailure", "AssetMisconfiguration"]

--- a/src/soar_sdk/input_spec.py
+++ b/src/soar_sdk/input_spec.py
@@ -1,5 +1,5 @@
 from uuid import uuid4
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, validator
 from typing import Literal, Optional, Any
 import random
 
@@ -65,6 +65,22 @@ class ActionParameter(BaseModel):
         extra = "allow"
 
 
+class SoarAuth(BaseModel):
+    """Information to help authenticate with SOAR."""
+
+    phantom_url: str
+    username: str
+    password: str
+
+    @validator("phantom_url")
+    def validate_phantom_url(cls, value: str) -> str:
+        return (
+            f"https://{value}"
+            if not value.startswith(("http://", "https://"))
+            else value
+        )
+
+
 class InputSpecification(BaseModel):
     """Input specification for SOAR app _handle_action() method.
 
@@ -127,3 +143,4 @@ class InputSpecification(BaseModel):
     identifier: str
     parameters: list[ActionParameter] = Field(default_factory=lambda: [{}])
     user_session_token: str = ""
+    soar_auth: Optional[SoarAuth] = None

--- a/src/soar_sdk/shims/phantom/base_connector.py
+++ b/src/soar_sdk/shims/phantom/base_connector.py
@@ -156,7 +156,7 @@ if TYPE_CHECKING or not _soar_is_available:
         def _prepare_container(self, container: dict) -> None:
             if ph_jsons.APP_JSON_ASSET_ID not in container:
                 raise ValueError(
-                    f"Missing {ph_jsons.APP_JSON_ASSET_ID}, {ph_jsons.APP_JSON_INGEST_APP_ID} keys in container"
+                    f"Missing {ph_jsons.APP_JSON_ASSET_ID} keys in container"
                 )
 
             container.update(
@@ -174,7 +174,7 @@ if TYPE_CHECKING or not _soar_is_available:
                     artifact.update(
                         {
                             k: v
-                            for k, v in self.__artifact_common.items()
+                            for k, v in self._artifact_common.items()
                             if (not artifact.get(k))
                         }
                     )

--- a/src/soar_sdk/shims/phantom/base_connector.py
+++ b/src/soar_sdk/shims/phantom/base_connector.py
@@ -33,8 +33,10 @@ if TYPE_CHECKING or not _soar_is_available:
                 ph_jsons.APP_JSON_DESCRIPTION: "Artifact added by sdk app",
                 ph_jsons.APP_JSON_RUN_AUTOMATION: False,  # Don't run any playbooks, when this artifact is added
             }
-
-            self.__container_common = {}  # Todo
+            self.__container_common = {
+                ph_jsons.APP_JSON_DESCRIPTION: "Container added by sdk app",
+                ph_jsons.APP_JSON_RUN_AUTOMATION: False,  # Don't run any playbooks, when this container is added
+            }
 
         @staticmethod
         def _get_phantom_base_url() -> str:
@@ -141,17 +143,22 @@ if TYPE_CHECKING or not _soar_is_available:
             return self._save_artifact(artifact)
 
         @abc.abstractmethod
-        def __save__containers(
-            self, containers: list[dict], fail_on_duplicate: bool = False
-        ) -> tuple[bool, str, Optional[list]]:
+        def _save_container(
+            self, container: dict, fail_on_duplicate: bool = False
+        ) -> tuple[bool, str, Optional[int]]:
             pass
 
-        def save_containers(
-            self, containers: list[dict], fail_on_duplicate: bool = False
-        ) -> tuple[bool, str, Optional[list]]:
-            return self.__save__containers(containers, fail_on_duplicate)
+        def save_container(
+            self, container: dict, fail_on_duplicate: bool = False
+        ) -> tuple[bool, str, Optional[int]]:
+            return self._save_container(container, fail_on_duplicate)
 
         def _prepare_container(self, container: dict) -> None:
+            if ph_jsons.APP_JSON_ASSET_ID not in container:
+                raise ValueError(
+                    f"Missing {ph_jsons.APP_JSON_ASSET_ID}, {ph_jsons.APP_JSON_INGEST_APP_ID} keys in container"
+                )
+
             container.update(
                 {
                     k: v
@@ -171,6 +178,29 @@ if TYPE_CHECKING or not _soar_is_available:
                             if (not artifact.get(k))
                         }
                     )
+
+        def _process_container_artifacts_response(
+            self, artifact_resp_data: list[dict]
+        ) -> None:
+            for resp_datum in artifact_resp_data:
+                if "id" in resp_datum:
+                    self.debug_print("Added artifact")
+                    continue
+
+                if "existing_artifact_id" in resp_datum:
+                    self.debug_print("Duplicate artifact found")
+                    continue
+
+                if "failed" in resp_datum:
+                    msg_cause = resp_datum.get("message", "NONE_GIVEN")
+                    message = (
+                        f"artifact addition failed, reason from server: {msg_cause}"
+                    )
+                    self.error_print(message)
+                    continue
+
+                message = "Artifact addition failed, Artifact ID was not returned"
+                self.error_print(message)
 
 
 __all__ = ["BaseConnector"]

--- a/src/soar_sdk/shims/phantom/consts.py
+++ b/src/soar_sdk/shims/phantom/consts.py
@@ -1,0 +1,19 @@
+try:
+    from phantom import consts
+
+    _soar_is_available = True
+except ImportError:
+    _soar_is_available = False
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING or not _soar_is_available:
+
+    class Consts:
+        APP_DEFAULT_ARTIFACT_LABEL = "artifact"
+        APP_DEFAULT_CONTAINER_LABEL = "incident"
+        APP_DEFAULT_ARTIFACT_TYPE = "network"
+
+    consts = Consts()
+
+__all__ = ["consts"]

--- a/src/soar_sdk/shims/phantom/json_keys.py
+++ b/src/soar_sdk/shims/phantom/json_keys.py
@@ -15,6 +15,7 @@ if TYPE_CHECKING or not _soar_is_available:
         APP_JSON_DESCRIPTION = "description"
         APP_JSON_RUN_AUTOMATION = "run_automation"
         APP_JSON_TYPE = "type"
+        APP_JSON_ASSET_ID = "asset_id"
 
     json_keys = JsonKeyShim()
 

--- a/src/soar_sdk/shims/phantom/json_keys.py
+++ b/src/soar_sdk/shims/phantom/json_keys.py
@@ -1,0 +1,21 @@
+try:
+    from phantom import json_keys
+
+    _soar_is_available = True
+except ImportError:
+    _soar_is_available = False
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING or not _soar_is_available:
+
+    class JsonKeyShim:
+        APP_JSON_LABEL = "label"
+        APP_JSON_INGEST_APP_ID = "ingest_app_id"
+        APP_JSON_DESCRIPTION = "description"
+        APP_JSON_RUN_AUTOMATION = "run_automation"
+        APP_JSON_TYPE = "type"
+
+    json_keys = JsonKeyShim()
+
+__all__ = ["json_keys"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,7 +7,7 @@ from soar_sdk.actions_provider import ActionsProvider
 from soar_sdk.app import App
 from soar_sdk.asset import BaseAsset
 from soar_sdk.connector import AppConnector
-from soar_sdk.input_spec import AppConfig, InputSpecification, EnvironmentVariable
+from soar_sdk.input_spec import AppConfig, InputSpecification, SoarAuth
 from soar_sdk.action_results import ActionOutput
 from soar_sdk.meta.dependencies import UvWheel
 from tests.stubs import SampleActionParams
@@ -221,15 +221,11 @@ def action_input_soar_auth() -> InputSpecification:
         config=AppConfig(
             app_version="1.0.0", directory=".", main_module="example_connector.py"
         ),
-        environment_variables={
-            "PHANTOM_BASE_URL": EnvironmentVariable(
-                type="string", value="https://10.34.5.6"
-            ),
-            "PHANTOM_USER": EnvironmentVariable(
-                type="string", value="soar_local_admin"
-            ),
-            "PHANTOM_PASSWORD": EnvironmentVariable(type="string", value="password"),
-        },
+        soar_auth=SoarAuth(
+            phantom_url="https://10.34.5.6",
+            username="soar_local_admin",
+            password="password",
+        ),
     )
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -288,3 +288,14 @@ def mock_post_any_soar_call(respx_mock):
         )
     )
     return mock_route
+
+
+@pytest.fixture
+@pytest.mark.respx
+def mock_post_container(respx_mock):
+    mock_route = respx_mock.post(re.compile(r".*/rest/container/?$")).mock(
+        return_value=Response(
+            201, json={"message": "Mocked container created", "id": 1}
+        )
+    )
+    return mock_route

--- a/tests/example_app/src/app.py
+++ b/tests/example_app/src/app.py
@@ -34,7 +34,7 @@ app = App(
 
 
 @app.test_connectivity()
-def test_connectivity(client: SOARClient, asset: Asset) -> None:
+def test_connectivity(soar: SOARClient, asset: Asset) -> None:
     logger.info(f"testing connectivity against {asset.base_url}")
 
 
@@ -47,9 +47,7 @@ class ReverseStringOutput(ActionOutput):
 
 
 @app.action(action_type="test", verbose="Reverses a string.")
-def reverse_string(
-    param: ReverseStringParams, client: SOARClient
-) -> ReverseStringOutput:
+def reverse_string(param: ReverseStringParams, soar: SOARClient) -> ReverseStringOutput:
     logger.debug("params: %s", param)
     reversed_string = param.input_string[::-1]
     logger.debug("reversed_string %s", reversed_string)

--- a/tests/test_actions_provider.py
+++ b/tests/test_actions_provider.py
@@ -139,19 +139,19 @@ def test_action_called_with_multiple_results_set(
     example_app: App, simple_action_input: InputSpecification
 ):
     # FIXME: this is phantom_lib integration check and should be moved from here
-    client = example_app.actions_provider.soar_client
+    soar = example_app.actions_provider.soar_client
 
     @example_app.action()
-    def test_action(params: Params, client: SOARClient) -> ActionOutput:
+    def test_action(params: Params, soar: SOARClient) -> ActionOutput:
         action_result1 = ActionResult(True, "Testing function run 1")
         action_result2 = ActionResult(True, "Testing function run 2")
-        client.add_result(action_result1)
-        client.add_result(action_result2)
+        soar.add_result(action_result1)
+        soar.add_result(action_result2)
         return True, "Multiple action results set"
 
     example_app.handle(simple_action_input.json())
 
-    assert len(client.get_action_results()) == 3
+    assert len(soar.get_action_results()) == 3
 
 
 def test_actions_provider_running_legacy_handler(example_provider, simple_action_input):

--- a/tests/test_adapters.py
+++ b/tests/test_adapters.py
@@ -20,6 +20,8 @@ def test_legacy_connector_adapter_delegates_method_calls():
     adapter.debug(mock.Mock())
     adapter.error(mock.Mock())
     adapter.add_exception(mock.Mock())
+    adapter.authenticate_soar_client(mock.Mock())
+    assert adapter.client is not None
 
     for method_name in adapter.connector.mocked_methods:
         mocked_method = getattr(adapter.connector, method_name)

--- a/tests/test_adapters.py
+++ b/tests/test_adapters.py
@@ -2,6 +2,7 @@ from unittest import mock
 
 from soar_sdk.adapters import LegacyConnectorAdapter
 from tests.stubs import BaseConnectorMock
+import pytest
 
 
 def test_legacy_connector_adapter_delegates_method_calls():
@@ -21,7 +22,8 @@ def test_legacy_connector_adapter_delegates_method_calls():
     adapter.error(mock.Mock())
     adapter.add_exception(mock.Mock())
     adapter.authenticate_soar_client(mock.Mock())
-    assert adapter.client is not None
+    with pytest.raises(NotImplementedError):
+        _ = adapter.client
 
     for method_name in adapter.connector.mocked_methods:
         mocked_method = getattr(adapter.connector, method_name)

--- a/tests/test_app_action.py
+++ b/tests/test_app_action.py
@@ -8,6 +8,7 @@ from soar_sdk.params import Param, Params
 from soar_sdk.action_results import ActionOutput
 from tests.stubs import SampleActionParams, SampleNestedOutput, SampleOutput
 from soar_sdk.exceptions import ActionFailure
+from httpx import Response, RequestError
 
 
 class SampleParams(Params):
@@ -288,4 +289,156 @@ def test_other_failure_raised(simple_app: App, app_connector):
 
     result = action_function(Params(), client=app_connector)
 
+    assert not result
+
+
+def test_save_artifact(simple_app: App, app_connector, mock_post_artifact):
+    app_connector.csrf_token = "fake_csrf_token"
+
+    @simple_app.action()
+    def action_function(params: Params, client: SOARClient) -> ActionOutput:
+        artifact = {
+            "name": "test artifact",
+            "container_id": 1,
+            "cef": {
+                "fileName": "test.txt",
+            },
+            "run_automation": False,
+            "source_data_identifier": None,
+        }
+        client.save_artifact(artifact)
+        return ActionOutput()
+
+    result = action_function(Params(), client=app_connector)
+    assert mock_post_artifact.called
+
+
+def test_save_artifact_bad_json(simple_app: App, app_connector):
+    @simple_app.action()
+    def action_function(params: Params, client: SOARClient) -> ActionOutput:
+        artifact = {"name": "test", "data": {1, 2, 3}}
+        client.save_artifact(artifact)
+        return ActionOutput()
+
+    result = action_function(Params(), client=app_connector)
+    assert not result
+
+
+def test_save_artifact_failed(simple_app: App, app_connector, mock_post_artifact):
+    app_connector.csrf_token = "fake_csrf_token"
+    mock_post_artifact.return_value = Response(
+        status_code=200, json={"failed": "something went wrong"}
+    )
+
+    @simple_app.action()
+    def action_function(params: Params, client: SOARClient) -> ActionOutput:
+        artifact = {
+            "name": "test artifact",
+            "container_id": 1,
+            "run_automation": False,
+            "source_data_identifier": None,
+        }
+        client.save_artifact(artifact)
+        return ActionOutput()
+
+    result = action_function(Params(), client=app_connector)
+    assert not result
+
+
+def test_save_artifact_exisiting_id(simple_app: App, app_connector, mock_post_artifact):
+    app_connector.csrf_token = "fake_csrf_token"
+    mock_post_artifact.return_value = Response(
+        status_code=201, json={"existing_artifact_id": "2"}
+    )
+
+    @simple_app.action()
+    def action_function(params: Params, client: SOARClient) -> ActionOutput:
+        artifact = {
+            "name": "test artifact",
+            "container_id": 1,
+            "run_automation": False,
+            "source_data_identifier": None,
+        }
+        client.save_artifact(artifact)
+        return ActionOutput()
+
+    result = action_function(Params(), client=app_connector)
+    assert result
+
+
+def test_save_artifact_locally(simple_app: App, app_connector):
+    app_connector.csrf_token = None
+
+    @simple_app.action()
+    def action_function(params: Params, client: SOARClient) -> ActionOutput:
+        artifact = {
+            "name": "test artifact",
+            "container_id": 1,
+            "run_automation": False,
+            "source_data_identifier": None,
+        }
+        client.save_artifact(artifact)
+        return ActionOutput()
+
+    result = action_function(Params(), client=app_connector)
+    assert result
+
+
+def test_save_artifact_locally_missing_container(simple_app: App, app_connector):
+    app_connector.csrf_token = None
+
+    @simple_app.action()
+    def action_function(params: Params, client: SOARClient) -> ActionOutput:
+        artifact = {
+            "name": "test artifact",
+            "run_automation": False,
+            "source_data_identifier": None,
+        }
+        client.save_artifact(artifact)
+        return ActionOutput()
+
+    result = action_function(Params(), client=app_connector)
+    assert not result
+
+
+def test_client_get(simple_app: App, app_connector, mock_get_any_soar_call):
+    app_connector.csrf_token = "fake_csrf_token"
+
+    @simple_app.action()
+    def action_function(params: Params, client: SOARClient) -> ActionOutput:
+        client.get("test")
+        return ActionOutput()
+
+    result = action_function(Params(), client=app_connector)
+    assert mock_get_any_soar_call.called
+
+
+def test_client_put(simple_app: App, app_connector, mock_put_any_call):
+    app_connector.csrf_token = "fake_csrf_token"
+
+    @simple_app.action()
+    def action_function(params: Params, client: SOARClient) -> ActionOutput:
+        client.put("test")
+        return ActionOutput()
+
+    result = action_function(Params(), client=app_connector)
+    assert mock_put_any_call.called
+
+
+def test_artifact_creation_failed(simple_app: App, app_connector, mock_post_artifact):
+    app_connector.csrf_token = "fake_csrf_token"
+    mock_post_artifact.side_effect = RequestError("Failed to create artifact")
+
+    @simple_app.action()
+    def action_function(params: Params, client: SOARClient) -> ActionOutput:
+        artifact = {
+            "name": "test artifact",
+            "container_id": 1,
+            "run_automation": False,
+            "source_data_identifier": None,
+        }
+        client.save_artifact(artifact)
+        return ActionOutput()
+
+    result = action_function(Params(), client=app_connector)
     assert not result

--- a/tests/test_app_action.py
+++ b/tests/test_app_action.py
@@ -68,7 +68,7 @@ def test_action_decoration_fails_with_params_not_inheriting_from_Params(simple_a
 
 def test_action_decoration_passing_params_type_as_hint(simple_app):
     @simple_app.action()
-    def foo(params: SampleActionParams, client: SOARClient) -> ActionOutput:
+    def foo(params: SampleActionParams, soar: SOARClient) -> ActionOutput:
         assert True
 
     foo(SampleActionParams())
@@ -76,7 +76,7 @@ def test_action_decoration_passing_params_type_as_hint(simple_app):
 
 def test_action_decoration_passing_params_type_as_argument(simple_app):
     @simple_app.action(params_class=SampleActionParams)
-    def foo(params, client: SOARClient) -> ActionOutput:
+    def foo(params, soar: SOARClient) -> ActionOutput:
         assert True
 
     foo(SampleActionParams())
@@ -84,7 +84,7 @@ def test_action_decoration_passing_params_type_as_argument(simple_app):
 
 def test_action_run_fails_with_wrong_params_type_passed(simple_app):
     @simple_app.action()
-    def action_example(params: Params, client: SOARClient) -> ActionOutput:
+    def action_example(params: Params, soar: SOARClient) -> ActionOutput:
         pass
 
     with pytest.raises(TypeError, match=r".*not inheriting from Params"):
@@ -93,31 +93,31 @@ def test_action_run_fails_with_wrong_params_type_passed(simple_app):
 
 def test_action_call_with_params(simple_app: App, sample_params: SampleParams):
     @simple_app.action()
-    def action_function(params: SampleParams, client: SOARClient) -> ActionOutput:
+    def action_function(params: SampleParams, soar: SOARClient) -> ActionOutput:
         assert params.int_value == 1
         assert params.str_value == "test"
         assert params.pass_value == "<PASSWORD>"
         assert params.bool_value
-        client.debug("TAG", "Progress was made")
+        soar.debug("TAG", "Progress was made")
 
     client_mock = mock.Mock(spec=SOARClient)
-    action_function(sample_params, client=client_mock)
+    action_function(sample_params, soar=client_mock)
     client_mock.debug.assert_called_once()
 
 
 def test_action_call_with_params_dict(simple_app, sample_params):
     @simple_app.action()
-    def action_function(params: SampleParams, client: SOARClient) -> ActionOutput:
+    def action_function(params: SampleParams, soar: SOARClient) -> ActionOutput:
         assert params.int_value == 1
         assert params.str_value == "test"
         assert params.pass_value == "<PASSWORD>"
         assert params.bool_value
-        client.debug("TAG", "Progress was made")
+        soar.debug("TAG", "Progress was made")
 
     client_mock = mock.Mock()
     client_mock.debug = mock.Mock()
 
-    action_function(sample_params, client=client_mock)
+    action_function(sample_params, soar=client_mock)
 
     assert client_mock.debug.call_count == 1
 
@@ -202,13 +202,13 @@ def test_action_decoration_uses_meta_identifier_for_action_name(simple_app):
 
 def test_action_with_mocked_client(simple_app, sample_params):
     @simple_app.action()
-    def action_function(params: SampleParams, client: SOARClient) -> ActionOutput:
-        client.save_progress("Progress was made")
+    def action_function(params: SampleParams, soar: SOARClient) -> ActionOutput:
+        soar.save_progress("Progress was made")
 
     client_mock = mock.Mock()
     client_mock.save_progress = mock.Mock()
 
-    action_function(sample_params, client=client_mock)
+    action_function(sample_params, soar=client_mock)
 
     assert client_mock.save_progress.call_count == 1
 
@@ -217,7 +217,7 @@ def test_action_decoration_fails_without_return_type(simple_app):
     with pytest.raises(TypeError, match=r".*must specify.*return type"):
 
         @simple_app.action()
-        def action_function(params: Params, client: SOARClient):
+        def action_function(params: Params, soar: SOARClient):
             pass
 
 
@@ -230,7 +230,7 @@ def test_action_decoration_fails_with_return_type_not_inheriting_from_ActionOutp
     with pytest.raises(TypeError, match=r".*Return type.*must be derived"):
 
         @simple_app.action()
-        def action_function(params: Params, client: SOARClient) -> SomeClass:
+        def action_function(params: Params, soar: SOARClient) -> SomeClass:
             pass
 
 
@@ -238,7 +238,7 @@ def test_action_cannot_be_test_connectivity(simple_app):
     with pytest.raises(TypeError, match=r".*test_connectivity.*reserved"):
 
         @simple_app.action()
-        def test_connectivity(params: Params, client: SOARClient) -> ActionOutput:
+        def test_connectivity(params: Params, soar: SOARClient) -> ActionOutput:
             pass
 
 
@@ -256,7 +256,7 @@ def test_action_names_must_be_unique(simple_app: App):
 
 def test_action_decoration_passing_output_type_as_hint(simple_app):
     @simple_app.action()
-    def foo(params: SampleActionParams, client: SOARClient) -> SampleOutput:
+    def foo(params: SampleActionParams, soar: SOARClient) -> SampleOutput:
         assert True
 
     foo(SampleActionParams())
@@ -264,7 +264,7 @@ def test_action_decoration_passing_output_type_as_hint(simple_app):
 
 def test_action_decoration_passing_output_type_as_argument(simple_app):
     @simple_app.action(output_class=SampleOutput)
-    def foo(params: SampleActionParams, client: SOARClient):
+    def foo(params: SampleActionParams, soar: SOARClient):
         assert True
 
     foo(SampleActionParams())
@@ -272,22 +272,22 @@ def test_action_decoration_passing_output_type_as_argument(simple_app):
 
 def test_action_failure_raised(simple_app: App):
     @simple_app.action()
-    def action_function(params: Params, client: SOARClient) -> ActionOutput:
+    def action_function(params: Params, soar: SOARClient) -> ActionOutput:
         raise ActionFailure("Action failed")
 
     client_mock = mock.Mock()
 
-    result = action_function(Params(), client=client_mock)
+    result = action_function(Params(), soar=client_mock)
     assert not result
     assert client_mock.add_result.call_count == 1
 
 
 def test_other_failure_raised(simple_app: App, app_connector):
     @simple_app.action()
-    def action_function(params: Params, client: SOARClient) -> ActionOutput:
+    def action_function(params: Params, soar: SOARClient) -> ActionOutput:
         raise ValueError("Value error occurred")
 
-    result = action_function(Params(), client=app_connector)
+    result = action_function(Params(), soar=app_connector)
 
     assert not result
 
@@ -296,7 +296,7 @@ def test_save_artifact(simple_app: App, app_connector, mock_post_artifact):
     app_connector.csrf_token = "fake_csrf_token"
 
     @simple_app.action()
-    def action_function(params: Params, client: SOARClient) -> ActionOutput:
+    def action_function(params: Params, soar: SOARClient) -> ActionOutput:
         artifact = {
             "name": "test artifact",
             "container_id": 1,
@@ -306,21 +306,22 @@ def test_save_artifact(simple_app: App, app_connector, mock_post_artifact):
             "run_automation": False,
             "source_data_identifier": None,
         }
-        client.save_artifact(artifact)
+        soar.save_artifact(artifact)
         return ActionOutput()
 
-    result = action_function(Params(), client=app_connector)
+    result = action_function(Params(), soar=app_connector)
+    assert result
     assert mock_post_artifact.called
 
 
 def test_save_artifact_bad_json(simple_app: App, app_connector):
     @simple_app.action()
-    def action_function(params: Params, client: SOARClient) -> ActionOutput:
+    def action_function(params: Params, soar: SOARClient) -> ActionOutput:
         artifact = {"name": "test", "data": {1, 2, 3}}
-        client.save_artifact(artifact)
+        soar.save_artifact(artifact)
         return ActionOutput()
 
-    result = action_function(Params(), client=app_connector)
+    result = action_function(Params(), soar=app_connector)
     assert not result
 
 
@@ -331,17 +332,17 @@ def test_save_artifact_failed(simple_app: App, app_connector, mock_post_artifact
     )
 
     @simple_app.action()
-    def action_function(params: Params, client: SOARClient) -> ActionOutput:
+    def action_function(params: Params, soar: SOARClient) -> ActionOutput:
         artifact = {
             "name": "test artifact",
             "container_id": 1,
             "run_automation": False,
             "source_data_identifier": None,
         }
-        client.save_artifact(artifact)
+        soar.save_artifact(artifact)
         return ActionOutput()
 
-    result = action_function(Params(), client=app_connector)
+    result = action_function(Params(), soar=app_connector)
     assert not result
 
 
@@ -352,17 +353,17 @@ def test_save_artifact_exisiting_id(simple_app: App, app_connector, mock_post_ar
     )
 
     @simple_app.action()
-    def action_function(params: Params, client: SOARClient) -> ActionOutput:
+    def action_function(params: Params, soar: SOARClient) -> ActionOutput:
         artifact = {
             "name": "test artifact",
             "container_id": 1,
             "run_automation": False,
             "source_data_identifier": None,
         }
-        client.save_artifact(artifact)
+        soar.save_artifact(artifact)
         return ActionOutput()
 
-    result = action_function(Params(), client=app_connector)
+    result = action_function(Params(), soar=app_connector)
     assert result
 
 
@@ -370,17 +371,17 @@ def test_save_artifact_locally(simple_app: App, app_connector):
     app_connector.csrf_token = None
 
     @simple_app.action()
-    def action_function(params: Params, client: SOARClient) -> ActionOutput:
+    def action_function(params: Params, soar: SOARClient) -> ActionOutput:
         artifact = {
             "name": "test artifact",
             "container_id": 1,
             "run_automation": False,
             "source_data_identifier": None,
         }
-        client.save_artifact(artifact)
+        soar.save_artifact(artifact)
         return ActionOutput()
 
-    result = action_function(Params(), client=app_connector)
+    result = action_function(Params(), soar=app_connector)
     assert result
 
 
@@ -388,16 +389,16 @@ def test_save_artifact_locally_missing_container(simple_app: App, app_connector)
     app_connector.csrf_token = None
 
     @simple_app.action()
-    def action_function(params: Params, client: SOARClient) -> ActionOutput:
+    def action_function(params: Params, soar: SOARClient) -> ActionOutput:
         artifact = {
             "name": "test artifact",
             "run_automation": False,
             "source_data_identifier": None,
         }
-        client.save_artifact(artifact)
+        soar.save_artifact(artifact)
         return ActionOutput()
 
-    result = action_function(Params(), client=app_connector)
+    result = action_function(Params(), soar=app_connector)
     assert not result
 
 
@@ -405,11 +406,12 @@ def test_client_get(simple_app: App, app_connector, mock_get_any_soar_call):
     app_connector.csrf_token = "fake_csrf_token"
 
     @simple_app.action()
-    def action_function(params: Params, client: SOARClient) -> ActionOutput:
-        client.get("test")
+    def action_function(params: Params, soar: SOARClient) -> ActionOutput:
+        soar.get("test")
         return ActionOutput()
 
-    result = action_function(Params(), client=app_connector)
+    result = action_function(Params(), soar=app_connector)
+    assert result
     assert mock_get_any_soar_call.called
 
 
@@ -417,11 +419,12 @@ def test_client_put(simple_app: App, app_connector, mock_put_any_call):
     app_connector.csrf_token = "fake_csrf_token"
 
     @simple_app.action()
-    def action_function(params: Params, client: SOARClient) -> ActionOutput:
-        client.put("test")
+    def action_function(params: Params, soar: SOARClient) -> ActionOutput:
+        soar.put("test")
+        assert result
         return ActionOutput()
 
-    result = action_function(Params(), client=app_connector)
+    result = action_function(Params(), soar=app_connector)
     assert mock_put_any_call.called
 
 
@@ -430,15 +433,15 @@ def test_artifact_creation_failed(simple_app: App, app_connector, mock_post_arti
     mock_post_artifact.side_effect = RequestError("Failed to create artifact")
 
     @simple_app.action()
-    def action_function(params: Params, client: SOARClient) -> ActionOutput:
+    def action_function(params: Params, soar: SOARClient) -> ActionOutput:
         artifact = {
             "name": "test artifact",
             "container_id": 1,
             "run_automation": False,
             "source_data_identifier": None,
         }
-        client.save_artifact(artifact)
+        soar.save_artifact(artifact)
         return ActionOutput()
 
-    result = action_function(Params(), client=app_connector)
+    result = action_function(Params(), soar=app_connector)
     assert not result

--- a/tests/test_app_action_results.py
+++ b/tests/test_app_action_results.py
@@ -13,12 +13,12 @@ def test_app_action_called_with_legacy_result_set_returns_this_result(simple_app
 
     @simple_app.action()
     def action_returning_action_result(
-        params: SampleActionParams, client: SOARClient
+        params: SampleActionParams, soar: SOARClient
     ) -> ActionOutput:
         return action_result
 
     result = action_returning_action_result(
-        SampleActionParams(field1=5), client=client_mock
+        SampleActionParams(field1=5), soar=client_mock
     )
 
     assert result is True
@@ -32,12 +32,12 @@ def test_app_action_called_with_simple_result_creates_the_result(simple_app):
 
     @simple_app.action()
     def action_returning_simple_result(
-        params: SampleActionParams, client: SOARClient
+        params: SampleActionParams, soar: SOARClient
     ) -> ActionOutput:
         return ActionOutput()
 
     result = action_returning_simple_result(
-        SampleActionParams(field1=5), client=client_mock
+        SampleActionParams(field1=5), soar=client_mock
     )
 
     assert result is True
@@ -59,12 +59,12 @@ def test_app_action_called_with_more_complex_result_creates_the_result(simple_ap
 
     @simple_app.action()
     def action_returning_complex_result(
-        params: SampleActionParams, client: SOARClient
+        params: SampleActionParams, soar: SOARClient
     ) -> SampleOutput:
         return output
 
     result = action_returning_complex_result(
-        SampleActionParams(field1=5), client=client_mock
+        SampleActionParams(field1=5), soar=client_mock
     )
     assert result is True
     assert client_mock.add_result.call_count == 1

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -150,3 +150,34 @@ def test_app_connector_finalize_saves_state(simple_connector: AppConnector):
             _CACHE_STATE_KEY: test_state,
         }
     )
+
+
+def test_authenticate_soar_client(
+    simple_connector: AppConnector,
+    action_input_soar_auth: InputSpecification,
+    mock_get_any_soar_call,
+    mock_post_any_soar_call,
+):
+    simple_connector.authenticate_soar_client(action_input_soar_auth)
+    mock_get_any_soar_call.call_count == 1
+    request = mock_get_any_soar_call.calls[0].request
+    assert request.url == "https://10.34.5.6/login"
+    assert simple_connector.client.headers["X-CSRFToken"] == "mocked_csrf_token"
+
+    mock_post_any_soar_call.call_count == 1
+    post_request = mock_post_any_soar_call.calls[0].request
+    assert post_request.url == "https://10.34.5.6/login"
+
+    assert (
+        simple_connector.client.headers["Cookie"]
+        == "sessionid=mocked_session_id;csrftoken=mocked_csrf_token"
+    )
+
+
+def test_authenticate_soar_client_on_platform(
+    simple_connector: AppConnector,
+    action_input_soar_platform_auth: InputSpecification,
+    mock_get_any_soar_call,
+):
+    simple_connector.authenticate_soar_client(action_input_soar_platform_auth)
+    mock_get_any_soar_call.call_count == 1

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -159,12 +159,12 @@ def test_authenticate_soar_client(
     mock_post_any_soar_call,
 ):
     simple_connector.authenticate_soar_client(action_input_soar_auth)
-    mock_get_any_soar_call.call_count == 1
+    assert mock_get_any_soar_call.call_count == 1
     request = mock_get_any_soar_call.calls[0].request
     assert request.url == "https://10.34.5.6/login"
     assert simple_connector.client.headers["X-CSRFToken"] == "mocked_csrf_token"
 
-    mock_post_any_soar_call.call_count == 1
+    assert mock_post_any_soar_call.call_count == 1
     post_request = mock_post_any_soar_call.calls[0].request
     assert post_request.url == "https://10.34.5.6/login"
 
@@ -180,4 +180,4 @@ def test_authenticate_soar_client_on_platform(
     mock_get_any_soar_call,
 ):
     simple_connector.authenticate_soar_client(action_input_soar_platform_auth)
-    mock_get_any_soar_call.call_count == 1
+    assert mock_get_any_soar_call.call_count == 1

--- a/tests/test_test_connectivity.py
+++ b/tests/test_test_connectivity.py
@@ -7,13 +7,13 @@ from unittest import mock
 
 def test_connectivity_decoration_fails_when_used_more_than_once(simple_app):
     @simple_app.test_connectivity()
-    def test_connectivity(client: SOARClient):
+    def test_connectivity(soar: SOARClient):
         pass
 
     with pytest.raises(TypeError) as exception_info:
 
         @simple_app.test_connectivity()
-        def test_connectivity2(client: SOARClient):
+        def test_connectivity2(soar: SOARClient):
             pass
 
     assert (
@@ -55,7 +55,7 @@ def test_connectivity_returns_not_none(simple_app):
     with pytest.raises(TypeError) as exception_info:
 
         @simple_app.test_connectivity()
-        def test_connectivity(client: SOARClient) -> ActionOutput:
+        def test_connectivity(soar: SOARClient) -> ActionOutput:
             return ActionOutput(bool=True)
 
     assert (
@@ -66,23 +66,23 @@ def test_connectivity_returns_not_none(simple_app):
 
 def test_connectivity_raises_with_no_type_hint(simple_app):
     @simple_app.test_connectivity()
-    def test_connectivity(client: SOARClient):
+    def test_connectivity(soar: SOARClient):
         return ActionOutput(bool=True)
 
     client_mock = mock.Mock()
-    result = test_connectivity(client=client_mock)
+    result = test_connectivity(soar=client_mock)
     assert not result
     assert client_mock.add_result.call_count == 1
 
 
 def test_connectivity_bubbles_up_errors(simple_app):
     @simple_app.test_connectivity()
-    def test_connectivity(client: SOARClient):
+    def test_connectivity(soar: SOARClient):
         raise RuntimeError("Test connectivity failed")
 
     client_mock = mock.Mock()
 
-    result = test_connectivity(client=client_mock)
+    result = test_connectivity(soar=client_mock)
     assert not result
     assert client_mock.add_exception.call_count == 1
     assert client_mock.add_result.call_count == 1
@@ -90,7 +90,7 @@ def test_connectivity_bubbles_up_errors(simple_app):
 
 def test_connectivity_run(simple_app):
     @simple_app.test_connectivity()
-    def test_connectivity(client: SOARClient) -> None:
+    def test_connectivity(soar: SOARClient) -> None:
         assert True
 
     assert test_connectivity()
@@ -98,10 +98,10 @@ def test_connectivity_run(simple_app):
 
 def test_connectivity_action_failed(simple_app):
     @simple_app.test_connectivity()
-    def test_connectivity(client: SOARClient) -> None:
+    def test_connectivity(soar: SOARClient) -> None:
         raise AssetMisconfiguration("Test connectivity failed")
 
     client_mock = mock.Mock()
-    result = test_connectivity(client=client_mock)
+    result = test_connectivity(soar=client_mock)
     assert not result
     assert client_mock.add_result.call_count == 1


### PR DESCRIPTION
- Create an authenticated soar client either when the connector is being used on the platform or if the soar url, ursername and password are passed in through the command line
- The authenticated soar client is attached to the SOARClient class and the AppConnector class specifically implements the get, post, put, save_artifact and save_container functions
- Change the client passed to an action from `client` to `soar`

Container created via the command line:
<img width="1723" alt="Screenshot 2025-05-18 at 8 40 16 PM" src="https://github.com/user-attachments/assets/8eeb013e-c12c-4cc4-bb27-37974bff3ca0" />

Artifact created via the command line: 
<img width="1728" alt="Screenshot 2025-05-18 at 8 41 18 PM" src="https://github.com/user-attachments/assets/cd10a8ac-9ff1-4572-a35b-accd6a5dea94" />

Request using the authenticated client on a soar instance:
<img width="1722" alt="Screenshot 2025-05-18 at 8 44 07 PM" src="https://github.com/user-attachments/assets/d0cb2bba-f095-464a-96bf-02eefadce9e0" />
