### PR TITLE
Miscellaneous fixes

### DIFF
--- a/.github/workflows/code_quality.yml
+++ b/.github/workflows/code_quality.yml
@@ -56,4 +56,4 @@ jobs:
           enable-cache: true
           python-version: ${{ matrix.python-version }}
       - name: Pytest + Coverage - ${{ matrix.python-version }}
-        run: uv run --locked pytest
+        run: uv run --locked pytest -n auto

--- a/app_templates/basic_app/pyproject.toml
+++ b/app_templates/basic_app/pyproject.toml
@@ -2,7 +2,6 @@
 name = "basic_app"
 version = "0.1.0"
 description = "This is the basic example SOAR app"
-main_module = "src.app:app"
 license = "Copyright"
 readme = "README.md"
 requires-python = ">=3.9, <3.14"
@@ -21,3 +20,6 @@ dev = [
     "pytest-watch>=4.2.0,<5",
     "ruff>=0.11.6,<1",
 ]
+
+[tool.soar.app]
+main_module = "src.app:app"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -208,6 +208,7 @@ strict_equality = true
 check_untyped_defs = true
 exclude = [
     'tests/.*',
+    'dist/.*',
 ]
 
 [[tool.mypy.overrides]]

--- a/src/soar_sdk/action_results.py
+++ b/src/soar_sdk/action_results.py
@@ -1,4 +1,4 @@
-from typing import Optional, get_origin, get_args, TypedDict, Any
+from typing import Optional, Union, get_origin, get_args, TypedDict, Any
 from collections.abc import Iterator
 from typing_extensions import NotRequired
 from pydantic import BaseModel, Field
@@ -30,11 +30,12 @@ class OutputFieldSpecification(TypedDict):
     data_path: str
     data_type: str
     contains: NotRequired[list[str]]
-    example_values: NotRequired[list[str]]
+    example_values: NotRequired[list[Union[str, float, bool]]]
 
 
 def OutputField(
-    cef_types: Optional[list[str]] = None, example_values: Optional[list[str]] = None
+    cef_types: Optional[list[str]] = None,
+    example_values: Optional[list[Union[str, float, bool]]] = None,
 ) -> Any:  # noqa: ANN401
     return Field(
         examples=example_values,

--- a/src/soar_sdk/action_results.py
+++ b/src/soar_sdk/action_results.py
@@ -87,4 +87,7 @@ class ActionOutput(BaseModel):
             if examples := field.field_info.extra.get("examples"):
                 schema_field["example_values"] = examples
 
+            if field_type is bool:
+                schema_field["example_values"] = [True, False]
+
             yield schema_field

--- a/src/soar_sdk/app.py
+++ b/src/soar_sdk/app.py
@@ -223,11 +223,11 @@ class App:
                 action=action_name,
                 identifier=identifier or function.__name__,
                 description=description or inspect.getdoc(function) or action_name,
-                verbose=verbose,  # FIXME: must start with a capital and end with full stop
+                verbose=verbose,
                 type=action_type,
                 read_only=read_only,
                 parameters=validated_params_class,
-                output=validated_output_class,  # FIXME: all output need to contain params
+                output=validated_output_class,
                 versions=versions,
                 view_handler=view_handler,
             )

--- a/src/soar_sdk/app.py
+++ b/src/soar_sdk/app.py
@@ -8,7 +8,11 @@ from collections.abc import Iterator
 
 from soar_sdk.asset import BaseAsset
 from soar_sdk.input_spec import InputSpecification
-from soar_sdk.compat import MIN_PHANTOM_VERSION, PythonVersion
+from soar_sdk.compat import (
+    MIN_PHANTOM_VERSION,
+    PythonVersion,
+    remove_when_soar_newer_than,
+)
 from soar_sdk.shims.phantom.base_connector import BaseConnector
 from soar_sdk.shims.phantom_common.app_interface.app_interface import SoarRestClient
 from soar_sdk.abstract import SOARClient
@@ -566,7 +570,9 @@ class App:
                 **kwargs: Any,  # noqa: ANN401
             ) -> str:
                 def handle_html_output(html: str) -> str:
-                    # TODO: remove_when_soar_newer_than()
+                    remove_when_soar_newer_than(
+                        "6.4.1", "SOAR now fully supports prerendering views"
+                    )
                     if context.get("accepts_prerender"):
                         context["prerender"] = True
                         return html

--- a/src/soar_sdk/app.py
+++ b/src/soar_sdk/app.py
@@ -8,6 +8,7 @@ from collections.abc import Iterator
 
 from soar_sdk.asset import BaseAsset
 from soar_sdk.input_spec import InputSpecification
+from soar_sdk.compat import MIN_PHANTOM_VERSION, PythonVersion
 from soar_sdk.shims.phantom.base_connector import BaseConnector
 from soar_sdk.shims.phantom_common.app_interface.app_interface import SoarRestClient
 from soar_sdk.abstract import SOARClient
@@ -58,8 +59,8 @@ class App:
         product_name: str,
         publisher: str,
         appid: str,
-        python_version: list[str] = ["3.9", "3.13"],  # noqa: B006
-        min_phantom_version: str = "6.4.0",
+        python_version: Optional[list[PythonVersion]] = None,
+        min_phantom_version: str = MIN_PHANTOM_VERSION,
         fips_compliant: bool = False,
         asset_cls: type[BaseAsset] = BaseAsset,
         legacy_connector_class: Optional[type[BaseConnector]] = None,
@@ -69,6 +70,9 @@ class App:
         self.__logger = getLogger()
         if not is_valid_uuid(appid):
             raise ValueError(f"Appid is not a valid uuid: {appid}")
+
+        if python_version is None:
+            python_version = PythonVersion.all()
 
         self.app_meta_info = {
             "name": name,

--- a/src/soar_sdk/asset.py
+++ b/src/soar_sdk/asset.py
@@ -12,7 +12,7 @@ from soar_sdk.input_spec import AppConfig
 def AssetField(
     description: Optional[str] = None,
     required: bool = True,
-    default: Optional[str] = None,
+    default: Optional[Any] = None,  # noqa: ANN401
     value_list: Optional[list] = None,
     sensitive: bool = False,
 ) -> Any:  # noqa: ANN401

--- a/src/soar_sdk/cli/manifests/processors.py
+++ b/src/soar_sdk/cli/manifests/processors.py
@@ -7,6 +7,7 @@ from pprint import pprint
 
 from soar_sdk.app import App
 from soar_sdk.cli.path_utils import context_directory
+from soar_sdk.compat import remove_when_soar_newer_than
 from soar_sdk.meta.adapters import TOMLDataAdapter
 from soar_sdk.meta.app import AppMeta
 from soar_sdk.meta.dependencies import UvLock
@@ -39,9 +40,9 @@ class ManifestProcessor:
         )
 
         if app.webhook_meta is not None:
+            remove_when_soar_newer_than("6.4.0")
             app_meta.webhook = app.webhook_meta
             app_meta.webhook.handler = (
-                # TODO: remove `replace` call once Borg is n-2
                 f"{app_meta.main_module.replace(':', '.')}.handle_webhook"
             )
 

--- a/src/soar_sdk/cli/package/cli.py
+++ b/src/soar_sdk/cli/package/cli.py
@@ -23,7 +23,7 @@ from itertools import chain
 import os
 import httpx
 
-package = typer.Typer(invoke_without_command=True)
+package = typer.Typer()
 console = Console()  # For printing lots of pretty colors and stuff
 
 

--- a/src/soar_sdk/compat.py
+++ b/src/soar_sdk/compat.py
@@ -1,0 +1,19 @@
+from enum import Enum
+
+MIN_PHANTOM_VERSION = "6.4.0"
+
+
+class PythonVersion(str, Enum):
+    """
+    Enum to represent supported Python versions.
+    """
+
+    PY_3_9 = "3.9"
+    PY_3_13 = "3.13"
+
+    @classmethod
+    def all(cls) -> list["PythonVersion"]:
+        """
+        Returns a list of all supported Python versions.
+        """
+        return [cls.PY_3_9, cls.PY_3_13]

--- a/src/soar_sdk/compat.py
+++ b/src/soar_sdk/compat.py
@@ -1,6 +1,19 @@
 from enum import Enum
+import functools
+from packaging.version import Version
 
 MIN_PHANTOM_VERSION = "6.4.0"
+
+
+@functools.lru_cache(maxsize=32)
+def remove_when_soar_newer_than(
+    version: str, message: str = "", *, base_version: str = MIN_PHANTOM_VERSION
+) -> None:
+    if not message:
+        message = "This code should be removed!"
+
+    if Version(version) < Version(base_version):
+        raise RuntimeError(f"Support for SOAR {version} is over. {message}")
 
 
 class PythonVersion(str, Enum):

--- a/src/soar_sdk/meta/actions.py
+++ b/src/soar_sdk/meta/actions.py
@@ -11,10 +11,10 @@ class ActionMeta(BaseModel):
     action: str
     identifier: str
     description: str
-    verbose: str
     type: str  # contain, correct, generic, investigate or test
     read_only: bool
     versions: str
+    verbose: str = ""
     parameters: Type[Params] = Field(default=Params)  # noqa: UP006
     output: Type[ActionOutput] = Field(default=ActionOutput)  # noqa: UP006
     view_handler: Optional[Callable] = None

--- a/src/soar_sdk/meta/actions.py
+++ b/src/soar_sdk/meta/actions.py
@@ -3,6 +3,7 @@ from typing import Any, Type, Optional, Callable  # noqa: UP035
 from pydantic import BaseModel, Field
 
 from soar_sdk.cli.manifests.serializers import ParamsSerializer, OutputsSerializer
+from soar_sdk.compat import remove_when_soar_newer_than
 from soar_sdk.params import Params
 from soar_sdk.action_results import ActionOutput
 
@@ -27,7 +28,7 @@ class ActionMeta(BaseModel):
         )
 
         if self.view_handler:
-            # TODO: remove_when_soar_newer_than()
+            remove_when_soar_newer_than("6.4.1")
             # Get the module path and function name for the view
             module = self.view_handler.__module__
             # Convert module path from dot notation to the expected format

--- a/src/soar_sdk/meta/adapters.py
+++ b/src/soar_sdk/meta/adapters.py
@@ -10,6 +10,7 @@ class TOMLDataAdapter:
             toml_data = toml.load(f)
 
         uv_app_data = toml_data.get("project", {})
+        sdk_tool_data = toml_data.get("tool", {}).get("soar", {}).get("app", {})
         project_name = uv_app_data.get("name")
         package_name = (
             f"phantom_{project_name}"
@@ -24,6 +25,6 @@ class TOMLDataAdapter:
                 license=uv_app_data.get("license"),
                 package_name=package_name,
                 project_name=project_name,
-                main_module=uv_app_data.get("main_module"),
+                main_module=sdk_tool_data.get("main_module"),
             )
         )

--- a/src/soar_sdk/meta/app.py
+++ b/src/soar_sdk/meta/app.py
@@ -8,6 +8,10 @@ from .dependencies import DependencyList
 from .webhooks import WebhookMeta
 
 
+class AppContributor(BaseModel):
+    name: str
+
+
 class AppMeta(BaseModel):
     name: str = ""
     description: str
@@ -28,6 +32,7 @@ class AppMeta(BaseModel):
     publisher: str = ""
     utctime_updated: str = ""
     fips_compliant: bool = False
+    contributors: list[AppContributor] = Field(default_factory=list)
 
     configuration: dict = Field(default_factory=dict)
     actions: list[ActionMeta] = Field(default_factory=list)

--- a/src/soar_sdk/meta/app.py
+++ b/src/soar_sdk/meta/app.py
@@ -1,6 +1,8 @@
 from pydantic import BaseModel, Field
 from typing import Optional
 
+from soar_sdk.compat import PythonVersion
+
 from .actions import ActionMeta
 from .dependencies import DependencyList
 from .webhooks import WebhookMeta
@@ -21,7 +23,7 @@ class AppMeta(BaseModel):
     logo: str = ""
     logo_dark: str = ""
     product_name: str = ""
-    python_version: list[str] = ["3.9", "3.13"]
+    python_version: list[PythonVersion] = Field(default_factory=PythonVersion.all)
     product_version_regex: str = ".*"
     publisher: str = ""
     utctime_updated: str = ""

--- a/src/soar_sdk/meta/dependencies.py
+++ b/src/soar_sdk/meta/dependencies.py
@@ -7,6 +7,8 @@ from logging import getLogger
 import httpx
 import hashlib
 
+from soar_sdk.compat import remove_when_soar_newer_than
+
 
 logger = getLogger(__name__)
 
@@ -45,9 +47,12 @@ class UvWheel(BaseModel):
     # The wheel file name is specified by PEP427. It's either a 5- or 6-tuple:
     # {distribution}-{version}(-{build tag})?-{python tag}-{abi tag}-{platform tag}.whl
     # We can parse this to determine which configurations it supports.
-    # TODO: when we upgrade to pydantic 2, we can replace these properties with cached properties.
     @property
     def basename(self) -> str:
+        remove_when_soar_newer_than(
+            "6.4.0",
+            "We should be able to adopt pydantic 2 now, and turn this into a cached property.",
+        )
         filename = self.url.split("/")[-1]
         return filename.removesuffix(".whl")
 

--- a/src/soar_sdk/params.py
+++ b/src/soar_sdk/params.py
@@ -11,7 +11,7 @@ def Param(
     description: Optional[str] = None,
     required: bool = True,
     primary: bool = False,
-    default: Optional[str] = None,
+    default: Optional[Any] = None,  # noqa: ANN401
     value_list: Optional[list] = None,
     cef_types: Optional[list] = None,
     allow_list: bool = False,

--- a/src/soar_sdk/shims/phantom/vault.py
+++ b/src/soar_sdk/shims/phantom/vault.py
@@ -158,7 +158,7 @@ else:
 
     @dataclass
     class VaultEntry:
-        id: int
+        id: str
         file_path: str
         name: str
         container_id: int

--- a/tests/cli/manifests/test_processors.py
+++ b/tests/cli/manifests/test_processors.py
@@ -48,18 +48,19 @@ def test_get_module_dot_path(main_module, dot_path):
     assert ManifestProcessor.get_module_dot_path(main_module) == dot_path
 
 
-def test_build_manifests():
+@pytest.mark.parametrize("app", ("example_app", "example_app_with_webhook"))
+def test_build_manifests(app: str):
     class mock_datetime(datetime):
         @classmethod
         def now(cls, tz: "_TzInfo | None" = timezone.utc) -> datetime:
             return datetime(year=2025, month=4, day=17, hour=12, tzinfo=tz)
 
-    for test_app in ["tests/example_app", "tests/example_app_with_webhook"]:
-        with mock.patch("soar_sdk.cli.manifests.processors.datetime", mock_datetime):
-            processor = ManifestProcessor("example_app.json", project_context=test_app)
-            app_meta = processor.build().to_json_manifest()
+    test_app = f"tests/{app}"
+    with mock.patch("soar_sdk.cli.manifests.processors.datetime", mock_datetime):
+        processor = ManifestProcessor("example_app.json", project_context=test_app)
+        app_meta = processor.build().to_json_manifest()
 
-        with open(f"{test_app}/app.json") as expected_json:
-            expected_meta = json.load(expected_json)
+    with open(f"{test_app}/app.json") as expected_json:
+        expected_meta = json.load(expected_json)
 
-        assert app_meta == expected_meta
+    assert app_meta == expected_meta

--- a/tests/cli/test_serializers.py
+++ b/tests/cli/test_serializers.py
@@ -175,6 +175,7 @@ def test_outputs_serialize_output_class():
         {
             "data_path": "action_result.data.*.nested_value.bool_value",
             "data_type": "boolean",
+            "example_values": [True, False],
         },
     ]
 
@@ -248,5 +249,6 @@ def test_outputs_serialize_with_parameters_class():
         {
             "data_path": "action_result.data.*.nested_value.bool_value",
             "data_type": "boolean",
+            "example_values": [True, False],
         },
     ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,7 @@ import pytest
 from soar_sdk.actions_provider import ActionsProvider
 from soar_sdk.app import App
 from soar_sdk.asset import BaseAsset
+from soar_sdk.compat import PythonVersion
 from soar_sdk.connector import AppConnector
 from soar_sdk.input_spec import AppConfig, InputSpecification, SoarAuth
 from soar_sdk.action_results import ActionOutput
@@ -77,6 +78,7 @@ def app_with_action() -> App:
         product_vendor="Splunk",
         product_name="Example App",
         publisher="Splunk",
+        python_version=[PythonVersion.PY_3_13],
     )
 
     @app.action(

--- a/tests/example_app/app.json
+++ b/tests/example_app/app.json
@@ -20,6 +20,7 @@
     "publisher": "Splunk Inc.",
     "utctime_updated": "2025-04-17T12:00:00.000000Z",
     "fips_compliant": false,
+    "contributors": [],
     "configuration": {
         "base_url": {
             "data_type": "string",

--- a/tests/example_app/pyproject.toml
+++ b/tests/example_app/pyproject.toml
@@ -3,7 +3,6 @@ name = "exampleapp"
 version = "0.1.0"
 description = "This is the basic example SOAR app"
 license = "Copyright (c) Splunk Inc., 2025"
-main_module = "src.app:app"
 readme = "README.md"
 requires-python = ">=3.9, <3.14"
 authors = [
@@ -27,6 +26,9 @@ dev = [
     "pytest-watch>=4.2.0,<5",
     "ruff>=0.11.6,<1",
 ]
+
+[tool.soar.app]
+main_module = "src.app:app"
 
 [[tool.uv.index]]
 url = "https://pypi.python.org/simple"

--- a/tests/example_app/src/__init__.py
+++ b/tests/example_app/src/__init__.py
@@ -1,5 +1,9 @@
-# TODO: This boilerplate is needed to support webhooks prior to Borg release.
-# It should be removed once Borg is n-2.
+from soar_sdk.compat import remove_when_soar_newer_than
+
+remove_when_soar_newer_than(
+    "6.4.0",
+    "This boilerplate is needed to support webhooks in older SOAR versions. This file can be cleared out now",
+)
 
 from . import app
 

--- a/tests/example_app/src/app.py
+++ b/tests/example_app/src/app.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 from typing import Union
 from collections.abc import Iterator
 from datetime import datetime, timezone

--- a/tests/example_app_with_webhook/app.json
+++ b/tests/example_app_with_webhook/app.json
@@ -17,6 +17,7 @@
     "publisher": "Splunk Inc.",
     "utctime_updated": "2025-04-17T12:00:00.000000Z",
     "fips_compliant": false,
+    "contributors": [],
     "webhook": {
         "handler": "src.app.app.handle_webhook",
         "requires_auth": true,

--- a/tests/example_app_with_webhook/pyproject.toml
+++ b/tests/example_app_with_webhook/pyproject.toml
@@ -3,7 +3,6 @@ name = "exampleapp"
 version = "0.1.0"
 description = "This is the basic example SOAR app"
 license = "Copyright (c) Splunk Inc., 2025"
-main_module = "src.app:app"
 readme = "README.md"
 requires-python = ">=3.9, <3.14"
 authors = [
@@ -27,6 +26,9 @@ dev = [
     "pytest-watch>=4.2.0,<5",
     "ruff>=0.11.6,<1",
 ]
+
+[tool.soar.app]
+main_module = "src.app:app"
 
 [[tool.uv.index]]
 url = "https://pypi.python.org/simple"

--- a/tests/example_app_with_webhook/src/__init__.py
+++ b/tests/example_app_with_webhook/src/__init__.py
@@ -1,5 +1,9 @@
-# TODO: This boilerplate is needed to support webhooks prior to Borg release.
-# It should be removed once Borg is n-2.
+from soar_sdk.compat import remove_when_soar_newer_than
+
+remove_when_soar_newer_than(
+    "6.4.0",
+    "This boilerplate is needed to support webhooks in older SOAR versions. This file can be cleared out now",
+)
 
 from . import app
 

--- a/tests/example_app_with_webhook/src/app.py
+++ b/tests/example_app_with_webhook/src/app.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 from io import BytesIO
 from soar_sdk.abstract import SOARClient
 from soar_sdk.app import App

--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -1,0 +1,22 @@
+import pytest
+from soar_sdk.compat import remove_when_soar_newer_than
+
+
+def test_raises_runtime_error_when_version_below_minimum():
+    """Test that function raises RuntimeError when version is below minimum."""
+    with pytest.raises(RuntimeError, match="Support for SOAR 1.0.0 is over"):
+        remove_when_soar_newer_than("1.0.0", base_version="2.0.0")
+
+
+def test_raises_runtime_error_with_custom_message():
+    """Test that function raises RuntimeError with custom message."""
+    custom_message = "Custom deprecation message"
+    with pytest.raises(RuntimeError, match=custom_message):
+        remove_when_soar_newer_than("1.5.0", custom_message, base_version="2.0.0")
+
+
+@pytest.mark.parametrize("version", ("2.0.0", "2.1.0", "3.0.0"))
+def test_no_error_when_version_equals_or_above_minimum(version):
+    """Test that no error is raised when version equals or is above minimum."""
+    # Should not raise any exception
+    remove_when_soar_newer_than(version, base_version="2.0.0")


### PR DESCRIPTION
### Changelog

* f7e3c7c - feat(ci): run pytest in parallel in CI
* 9547b45 - fix(pre-commit): mypy should ignore dist
* f807293 - fix(types): made type hints for param defaults and output examples more liberal
* 2fc8365 - fix(cli): running 'soarapps package' with no command now correctly prints help
* 1633910 - fix(actions): 'verbose' field on actions should be optional
* 73c3760 - fix(types): vault entry IDs should be str, not int
* d8bfc11 - fix(toml): moved main_module back into tool.soar.app
* d1fa116 - feat(outputs): automatically fill in example values for boolean datapaths
* 1e24e33 - fix: remove unneeded shebangs
* d0ac8c4 - refactor: centrally define supported SOAR and python versions
* b2eea46 - fix(manifest): include contributors in app metadata
* 5c637ca - refactor: added automatic tech debt detection with remove_when_soar_newer_than()
* b18e697 - chore: add concrete calls to remove_when_soar_newer_than
