### PR TITLE
fix: exclude the webhook settings from the manifest if they are None

### DIFF
--- a/src/soar_sdk/cli/manifests/processors.py
+++ b/src/soar_sdk/cli/manifests/processors.py
@@ -53,7 +53,7 @@ class ManifestProcessor:
         and save it back to the manifest file.
         """
         app_meta = self.build()
-        pprint(app_meta.dict(exclude_none=True))
+        pprint(app_meta.to_json_manifest())
 
         self.save_json_manifest(app_meta)
 
@@ -69,7 +69,7 @@ class ManifestProcessor:
 
     def save_json_manifest(self, app_meta: AppMeta) -> None:
         with open(self.manifest_path, "w") as f:
-            json.dump(app_meta.dict(exclude_none=True), f, indent=4)
+            json.dump(app_meta.to_json_manifest(), f, indent=4)
 
     @staticmethod
     def get_module_dot_path(main_module: str) -> str:

--- a/src/soar_sdk/cli/package/cli.py
+++ b/src/soar_sdk/cli/package/cli.py
@@ -167,7 +167,7 @@ def build(
                 app_meta.pip313_dependencies.wheel.append(wheel_entry)
 
             console.print("Writing manifest")
-            manifest_json = json.dumps(app_meta.dict(), indent=4).encode()
+            manifest_json = json.dumps(app_meta.to_json_manifest(), indent=4).encode()
             manifest_info = tarfile.TarInfo(f"{app_name}/manifest.json")
             manifest_info.size = len(manifest_json)
             app_tarball.addfile(manifest_info, BytesIO(manifest_json))

--- a/src/soar_sdk/meta/app.py
+++ b/src/soar_sdk/meta/app.py
@@ -34,3 +34,9 @@ class AppMeta(BaseModel):
     pip313_dependencies: DependencyList = Field(default_factory=DependencyList)
 
     webhook: Optional[WebhookMeta]
+
+    def to_json_manifest(self) -> dict:
+        """
+        Converts the AppMeta instance to a JSON-compatible dictionary.
+        """
+        return self.dict(exclude_none=True)

--- a/tests/cli/manifests/test_processors.py
+++ b/tests/cli/manifests/test_processors.py
@@ -57,7 +57,7 @@ def test_build_manifests():
     for test_app in ["tests/example_app", "tests/example_app_with_webhook"]:
         with mock.patch("soar_sdk.cli.manifests.processors.datetime", mock_datetime):
             processor = ManifestProcessor("example_app.json", project_context=test_app)
-            app_meta = processor.build().dict(exclude_none=True)
+            app_meta = processor.build().to_json_manifest()
 
         with open(f"{test_app}/app.json") as expected_json:
             expected_meta = json.load(expected_json)

--- a/tests/example_app/uv.lock
+++ b/tests/example_app/uv.lock
@@ -962,7 +962,7 @@ wheels = [
 
 [[package]]
 name = "splunk-soar-sdk"
-version = "1.0.0b21"
+version = "1.0.0b27"
 source = { directory = "../../" }
 dependencies = [
     { name = "beautifulsoup4", marker = "(python_full_version < '3.10' and platform_machine == 'arm64' and sys_platform == 'darwin') or (python_full_version >= '3.13' and platform_machine == 'arm64' and sys_platform == 'darwin') or (python_full_version < '3.10' and platform_machine == 'x86_64' and sys_platform == 'darwin') or (python_full_version >= '3.13' and platform_machine == 'x86_64' and sys_platform == 'darwin') or (python_full_version < '3.10' and platform_machine == 'aarch64' and sys_platform == 'linux') or (python_full_version >= '3.13' and platform_machine == 'aarch64' and sys_platform == 'linux') or (python_full_version < '3.10' and platform_machine == 'x86_64' and sys_platform == 'linux') or (python_full_version >= '3.13' and platform_machine == 'x86_64' and sys_platform == 'linux')" },

--- a/tests/example_app_with_webhook/uv.lock
+++ b/tests/example_app_with_webhook/uv.lock
@@ -962,7 +962,7 @@ wheels = [
 
 [[package]]
 name = "splunk-soar-sdk"
-version = "1.0.0b26"
+version = "1.0.0b27"
 source = { directory = "../../" }
 dependencies = [
     { name = "beautifulsoup4", marker = "(python_full_version < '3.10' and platform_machine == 'arm64' and sys_platform == 'darwin') or (python_full_version >= '3.13' and platform_machine == 'arm64' and sys_platform == 'darwin') or (python_full_version < '3.10' and platform_machine == 'x86_64' and sys_platform == 'darwin') or (python_full_version >= '3.13' and platform_machine == 'x86_64' and sys_platform == 'darwin') or (python_full_version < '3.10' and platform_machine == 'aarch64' and sys_platform == 'linux') or (python_full_version >= '3.13' and platform_machine == 'aarch64' and sys_platform == 'linux') or (python_full_version < '3.10' and platform_machine == 'x86_64' and sys_platform == 'linux') or (python_full_version >= '3.13' and platform_machine == 'x86_64' and sys_platform == 'linux')" },


### PR DESCRIPTION
If the app installer sees a `null` value for the `webhooks` entry, it fails to install the app. So we will make sure there are no None values included.