### PR TITLE
feat(actions): allow defining actions in separate modules

### DIFF
--- a/src/soar_sdk/exceptions.py
+++ b/src/soar_sdk/exceptions.py
@@ -46,8 +46,17 @@ class SoarAPIError(ActionFailure):
         )
 
 
+class ActionRegistrationError(Exception):
+    """Exception raised when there is an error registering an action."""
+
+    def __init__(self, action: str) -> None:
+        self.action = action
+        super().__init__(f"Error registering action: {action}")
+
+
 __all__ = [
     "ActionFailure",
+    "ActionRegistrationError",
     "AssetMisconfiguration",
     "SoarAPIError",
 ]

--- a/src/soar_sdk/exceptions.py
+++ b/src/soar_sdk/exceptions.py
@@ -46,17 +46,8 @@ class SoarAPIError(ActionFailure):
         )
 
 
-class ActionRegistrationError(Exception):
-    """Exception raised when there is an error registering an action."""
-
-    def __init__(self, action: str) -> None:
-        self.action = action
-        super().__init__(f"Error registering action: {action}")
-
-
 __all__ = [
     "ActionFailure",
-    "ActionRegistrationError",
     "AssetMisconfiguration",
     "SoarAPIError",
 ]

--- a/src/soar_sdk/exceptions.py
+++ b/src/soar_sdk/exceptions.py
@@ -46,4 +46,17 @@ class SoarAPIError(ActionFailure):
         )
 
 
-__all__ = ["ActionFailure", "AssetMisconfiguration"]
+class ActionRegistrationError(Exception):
+    """Exception raised when there is an error registering an action."""
+
+    def __init__(self, action: str) -> None:
+        self.action = action
+        super().__init__(f"Error registering action: {action}")
+
+
+__all__ = [
+    "ActionFailure",
+    "ActionRegistrationError",
+    "AssetMisconfiguration",
+    "SoarAPIError",
+]

--- a/src/soar_sdk/views/template_renderer.py
+++ b/src/soar_sdk/views/template_renderer.py
@@ -105,5 +105,14 @@ def get_templates_dir(function_globals: dict[str, Any]) -> str:
     caller_file = function_globals.get("__file__")
     if caller_file:
         app_dir = Path(caller_file).parent
+
+        # Walk up the directory tree looking for a templates directory
+        for current_dir in [app_dir, *list(app_dir.parents)]:
+            templates_dir = current_dir / "templates"
+            if templates_dir.exists() and templates_dir.is_dir():
+                return str(templates_dir)
+
+        # If no templates directory found, default to the app_dir level
         return str(app_dir.parent / "templates")
+
     return str(Path.cwd() / "templates")

--- a/tests/example_app/app.json
+++ b/tests/example_app/app.json
@@ -173,7 +173,7 @@
             ],
             "render": {
                 "type": "custom",
-                "view": "src.app.render_statistics_chart"
+                "view": "src.actions.generate_category.render_statistics_chart"
             }
         },
         {

--- a/tests/example_app/app.json
+++ b/tests/example_app/app.json
@@ -77,50 +77,12 @@
             "identifier": "reverse_string",
             "description": "reverse string",
             "verbose": "Reverses a string.",
-            "type": "test",
-            "read_only": true,
-            "versions": "EQ(*)",
-            "parameters": {
-                "input_string": {
-                    "order": 0,
-                    "name": "input_string",
-                    "description": "Input String",
-                    "data_type": "string",
-                    "required": true,
-                    "primary": false,
-                    "allow_list": false
-                }
-            },
-            "output": [
-                {
-                    "data_path": "action_result.status",
-                    "data_type": "string",
-                    "example_values": [
-                        "success",
-                        "failure"
-                    ]
-                },
-                {
-                    "data_path": "action_result.message",
-                    "data_type": "string"
-                },
-                {
-                    "data_path": "action_result.parameter.input_string",
-                    "data_type": "string"
-                },
-                {
-                    "data_path": "action_result.data.*.reversed_string",
-                    "data_type": "string"
-                }
-            ]
-        },
-        {
-            "action": "reverse string custom view",
-            "identifier": "reverse_string_custom_view",
-            "description": "reverse string custom view",
-            "verbose": "Reverses a string.",
             "type": "investigate",
             "read_only": true,
+            "render": {
+                "type": "custom",
+                "view": "src.actions.reverse_string.render_reverse_string_view"
+            },
             "versions": "EQ(*)",
             "parameters": {
                 "input_string": {
@@ -158,11 +120,7 @@
                     "data_path": "action_result.data.*.reversed_string",
                     "data_type": "string"
                 }
-            ],
-            "render": {
-                "type": "custom",
-                "view": "src.app.render_reverse_string_view"
-            }
+            ]
         },
         {
             "action": "generate statistics",

--- a/tests/example_app/src/actions/generate_category.py
+++ b/tests/example_app/src/actions/generate_category.py
@@ -1,0 +1,51 @@
+from soar_sdk.abstract import SOARClient
+from soar_sdk.action_results import ActionOutput
+from soar_sdk.params import Params
+from soar_sdk.views.components.pie_chart import PieChartData
+
+
+class StatisticsParams(Params):
+    category: str
+
+
+class StatisticsOutput(ActionOutput):
+    category: str
+    labels: list[str]
+    values: list[int]
+
+
+def render_statistics_chart(output: list[StatisticsOutput]) -> PieChartData:
+    stats = output[0]
+    colors = ["#4CAF50", "#2196F3", "#FF9800", "#F44336", "#9C27B0", "#607D8B"]
+
+    return PieChartData(
+        title=f"{stats.category} Distribution",
+        labels=stats.labels,
+        values=stats.values,
+        colors=colors,
+    )
+
+
+def generate_statistics(param: StatisticsParams, soar: SOARClient) -> StatisticsOutput:
+    if param.category.lower() == "test":
+        breakdown = {
+            "Malware": 45,
+            "Phishing": 32,
+            "Ransomware": 18,
+            "Data Breach": 12,
+            "DDoS": 8,
+        }
+    else:
+        breakdown = {
+            "Category A": 25,
+            "Category B": 35,
+            "Category C": 20,
+            "Category D": 15,
+            "Category E": 5,
+        }
+
+    return StatisticsOutput(
+        category=param.category,
+        labels=list(breakdown.keys()),
+        values=list(breakdown.values()),
+    )

--- a/tests/example_app/src/actions/reverse_string.py
+++ b/tests/example_app/src/actions/reverse_string.py
@@ -1,0 +1,31 @@
+from soar_sdk.logging import getLogger
+from soar_sdk.abstract import SOARClient
+from soar_sdk.action_results import ActionOutput
+from soar_sdk.params import Params
+
+logger = getLogger()
+
+
+class ReverseStringParams(Params):
+    input_string: str
+
+
+class ReverseStringOutput(ActionOutput):
+    original_string: str
+    reversed_string: str
+
+
+def reverse_string(param: ReverseStringParams, soar: SOARClient) -> ReverseStringOutput:
+    logger.debug("params: %s", param)
+    reversed_string = param.input_string[::-1]
+    logger.debug("reversed_string %s", reversed_string)
+    return ReverseStringOutput(
+        original_string=param.input_string, reversed_string=reversed_string
+    )
+
+
+def render_reverse_string_view(output: list[ReverseStringOutput]) -> dict:
+    return {
+        "original": output[0].original_string,
+        "reversed": output[0].reversed_string,
+    }

--- a/tests/example_app/src/app.py
+++ b/tests/example_app/src/app.py
@@ -44,47 +44,16 @@ def test_connectivity(soar: SOARClient, asset: Asset) -> None:
     logger.info(f"testing connectivity against {asset.base_url}")
 
 
-class ReverseStringParams(Params):
-    input_string: str
+from .actions.reverse_string import render_reverse_string_view
 
-
-class ReverseStringOutput(ActionOutput):
-    reversed_string: str
-
-
-@app.action(action_type="test", verbose="Reverses a string.")
-def reverse_string(param: ReverseStringParams, soar: SOARClient) -> ReverseStringOutput:
-    logger.debug("params: %s", param)
-    reversed_string = param.input_string[::-1]
-    logger.debug("reversed_string %s", reversed_string)
-    return ReverseStringOutput(reversed_string=reversed_string)
-
-
-class ReverseStringViewOutput(ActionOutput):
-    original_string: str
-    reversed_string: str
-
-
-@app.view_handler(template="reverse_string.html")
-def render_reverse_string_view(output: list[ReverseStringViewOutput]) -> dict:
-    return {
-        "original": output[0].original_string,
-        "reversed": output[0].reversed_string,
-    }
-
-
-@app.action(
+app.register_action(
+    "actions.reverse_string:reverse_string",
     action_type="investigate",
     verbose="Reverses a string.",
-    view_handler=render_reverse_string_view,
+    view_handler=app.view_handler(template="reverse_string_view.html")(
+        render_reverse_string_view
+    ),
 )
-def reverse_string_custom_view(
-    param: ReverseStringParams, soar: SOARClient
-) -> ReverseStringViewOutput:
-    reversed_string = param.input_string[::-1]
-    return ReverseStringViewOutput(
-        original_string=param.input_string, reversed_string=reversed_string
-    )
 
 
 class StatisticsParams(Params):

--- a/tests/example_app/src/app.py
+++ b/tests/example_app/src/app.py
@@ -4,11 +4,9 @@ from datetime import datetime, timezone
 from soar_sdk.abstract import SOARClient
 from soar_sdk.app import App
 from soar_sdk.asset import AssetField, BaseAsset
-from soar_sdk.params import Params, OnPollParams
-from soar_sdk.action_results import ActionOutput
+from soar_sdk.params import OnPollParams
 from soar_sdk.models.container import Container
 from soar_sdk.models.artifact import Artifact
-from soar_sdk.views.components.pie_chart import PieChartData
 from soar_sdk.logging import getLogger
 
 logger = getLogger()
@@ -44,69 +42,24 @@ def test_connectivity(soar: SOARClient, asset: Asset) -> None:
     logger.info(f"testing connectivity against {asset.base_url}")
 
 
-from .actions.reverse_string import render_reverse_string_view
+from .actions.reverse_string import render_reverse_string_view, reverse_string
 
 app.register_action(
-    "actions.reverse_string:reverse_string",
+    reverse_string,
     action_type="investigate",
     verbose="Reverses a string.",
-    view_handler=app.view_handler(template="reverse_string_view.html")(
-        render_reverse_string_view
-    ),
+    view_template="reverse_string.html",
+    view_handler=render_reverse_string_view,
 )
 
+from .actions.generate_category import render_statistics_chart, generate_statistics
 
-class StatisticsParams(Params):
-    category: str
-
-
-class StatisticsOutput(ActionOutput):
-    category: str
-    labels: list[str]
-    values: list[int]
-
-
-@app.view_handler()
-def render_statistics_chart(output: list[StatisticsOutput]) -> PieChartData:
-    stats = output[0]
-    colors = ["#4CAF50", "#2196F3", "#FF9800", "#F44336", "#9C27B0", "#607D8B"]
-
-    return PieChartData(
-        title=f"{stats.category} Distribution",
-        labels=stats.labels,
-        values=stats.values,
-        colors=colors,
-    )
-
-
-@app.action(
+app.register_action(
+    generate_statistics,
     action_type="investigate",
     verbose="Generate statistics with pie chart reusable component.",
     view_handler=render_statistics_chart,
 )
-def generate_statistics(param: StatisticsParams, soar: SOARClient) -> StatisticsOutput:
-    if param.category.lower() == "test":
-        breakdown = {
-            "Malware": 45,
-            "Phishing": 32,
-            "Ransomware": 18,
-            "Data Breach": 12,
-            "DDoS": 8,
-        }
-    else:
-        breakdown = {
-            "Category A": 25,
-            "Category B": 35,
-            "Category C": 20,
-            "Category D": 15,
-            "Category E": 5,
-        }
-
-    return StatisticsOutput(
-        category=param.category,
-        labels=list(breakdown.keys()),
-        values=list(breakdown.values()),
-    )
 
 
 @app.on_poll()

--- a/tests/mocks/importable_action.py
+++ b/tests/mocks/importable_action.py
@@ -7,3 +7,7 @@ def importable_action(params: Params) -> ActionOutput:
     Used by test_action_registration to test action registration via import paths
     """
     return ActionOutput()
+
+
+def importable_view_handler(output: list[ActionOutput]) -> dict:
+    return {"data": "test_data"}

--- a/tests/mocks/importable_action.py
+++ b/tests/mocks/importable_action.py
@@ -1,0 +1,9 @@
+from soar_sdk.action_results import ActionOutput
+from soar_sdk.params import Params
+
+
+def importable_action(params: Params) -> ActionOutput:
+    """
+    Used by test_action_registration to test action registration via import paths
+    """
+    return ActionOutput()

--- a/tests/test_template_renderer.py
+++ b/tests/test_template_renderer.py
@@ -98,3 +98,39 @@ def test_get_templates_dir_without_file_path():
     result = get_templates_dir(function_globals)
     expected = str(Path.cwd() / "templates")
     assert result == expected
+
+
+def test_get_templates_dir_fallback_when_no_templates_found():
+    with tempfile.TemporaryDirectory() as temp_dir:
+        nested_path = Path(temp_dir) / "app" / "src" / "actions"
+        nested_path.mkdir(parents=True)
+
+        module_file = nested_path / "my_module.py"
+        module_file.write_text("# fake module")
+
+        function_globals = {"__file__": str(module_file)}
+
+        result = get_templates_dir(function_globals)
+
+        expected = str(nested_path.parent / "templates")
+        assert result == expected
+
+
+def test_get_templates_dir_finds_existing_templates_directory():
+    with tempfile.TemporaryDirectory() as temp_dir:
+        app_root = Path(temp_dir) / "app"
+        templates_dir = app_root / "templates"
+        nested_path = app_root / "src" / "actions"
+
+        app_root.mkdir()
+        templates_dir.mkdir()
+        nested_path.mkdir(parents=True)
+
+        module_file = nested_path / "my_module.py"
+        module_file.write_text("# fake module")
+
+        function_globals = {"__file__": str(module_file)}
+
+        result = get_templates_dir(function_globals)
+
+        assert result == str(templates_dir)


### PR DESCRIPTION
Added new function: App.register_action(), which allows an app to dynamically import an action function that is defined in another module. 

Register_action only takes a function import for the action param. It also optionally takes the raw view_handler function and associated view_template 

Register action test with custom view:
https://10.1.65.149/mission/179/analyst/action_run/5331

<img width="1378" alt="Screenshot 2025-06-26 at 4 29 15 PM" src="https://github.com/user-attachments/assets/7182673e-adc7-4de6-8702-5e1fdae78543" />

