### PR TITLE
fix: pass soar client to webhooks handler

### DIFF
--- a/src/soar_sdk/abstract.py
+++ b/src/soar_sdk/abstract.py
@@ -6,7 +6,8 @@ from soar_sdk.apis.vault import Vault
 from soar_sdk.apis.artifact import Artifact
 from soar_sdk.apis.container import Container
 import httpx
-from dataclasses import dataclass
+from pydantic.dataclasses import dataclass
+from pydantic import validator
 
 JSONType = Union[dict[str, Any], list[Any], str, int, float, bool, None]
 
@@ -17,6 +18,14 @@ class SOARClientAuth:
     username: str = ""
     password: str = ""
     user_session_token: str = ""
+
+    @validator("base_url")
+    def validate_phantom_url(cls, value: str) -> str:
+        return (
+            f"https://{value}"
+            if not value.startswith(("http://", "https://"))
+            else value
+        )
 
 
 class SOARClient:

--- a/src/soar_sdk/shims/phantom_common/app_interface/app_interface.py
+++ b/src/soar_sdk/shims/phantom_common/app_interface/app_interface.py
@@ -21,8 +21,10 @@ if TYPE_CHECKING or not _soar_is_available:
 
             self.session = requests.Session()
             self.session.headers.update({"Cookie": f"sessionid={token}"})
+            self.username = ""
+            self.password = ""
 
-            self.is_authenticated = bool(token)
+            self.is_authenticated = bool(token) or (self.username and self.password)
 
 
 __all__ = ["SoarRestClient"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,6 +17,7 @@ from tests.stubs import SampleActionParams
 from pathlib import Path
 from httpx import Response
 import re
+from soar_sdk.abstract import SOARClient
 
 APP_ID = "9b388c08-67de-4ca4-817f-26f8fb7cbf55"
 
@@ -168,6 +169,36 @@ def app_with_asset_webhook() -> App:
     @app.webhook("test_webhook")
     def test_webhook_handler(request: WebhookRequest) -> WebhookResponse:
         """Test webhook handler."""
+        return WebhookResponse.text_response("Webhook received!")
+
+    return app
+
+
+@pytest.fixture
+def app_with_client_webhook() -> App:
+    """Create an app with a pre-configured action that requires an asset and webhook."""
+
+    class Asset(BaseAsset):
+        base_url: str
+
+    app = App(
+        asset_cls=Asset,
+        name="test_app_with_asset_webhook",
+        appid=APP_ID,
+        app_type="sandbox",
+        logo="logo.svg",
+        logo_dark="logo_dark.svg",
+        product_vendor="Splunk",
+        product_name="Example App",
+        publisher="Splunk",
+    ).enable_webhooks()
+
+    @app.webhook("test_webhook")
+    def test_webhook_handler(
+        request: WebhookRequest, soar: SOARClient
+    ) -> WebhookResponse:
+        """Test webhook handler."""
+        soar.get("rest/version")  # Example of using the SOAR client
         return WebhookResponse.text_response("Webhook received!")
 
     return app

--- a/tests/example_app/example_asset.json
+++ b/tests/example_app/example_asset.json
@@ -1,0 +1,4 @@
+{
+    "base_url": "https://soar-api.talos.cisco.com",
+    "api_key": "test"
+}

--- a/tests/example_app_with_webhook/src/app.py
+++ b/tests/example_app_with_webhook/src/app.py
@@ -58,8 +58,9 @@ def reverse_string(
 
 
 @app.webhook("test_webhook")
-def test_webhook(request: WebhookRequest[Asset]) -> WebhookResponse:
+def test_webhook(request: WebhookRequest[Asset], soar: SOARClient) -> WebhookResponse:
     logger.debug("Webhook request: %s", request)
+    soar.get("rest/version")
     response = WebhookResponse.text_response(
         content="Webhook received",
         status_code=200,

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -8,7 +8,7 @@ import pytest
 
 from soar_sdk.webhooks.models import WebhookRequest, WebhookResponse
 from soar_sdk.shims.phantom_common.app_interface.app_interface import SoarRestClient
-from soar_sdk.abstract import SOARClientAuth
+from soar_sdk.abstract import SOARClientAuth, SOARClient
 
 
 def test_app_run(example_app):
@@ -183,6 +183,39 @@ def test_handle_webhook_invalid_return_type_raises(
             asset={"base_url": "https://example.com"},
             soar_rest_client=SoarRestClient(token="test_token", asset_id=1),
         )
+
+
+def test_handle_webhook_soar_client(
+    app_with_asset_webhook: App, mock_get_any_soar_call, mock_delete_any_soar_call
+):
+    @app_with_asset_webhook.webhook("test_webhook_with_query")
+    def webhook_handler(request: WebhookRequest, soar: SOARClient) -> WebhookResponse:
+        assert request.query == {
+            "string_param": ["value"],
+            "list_param": ["value1", "value2"],
+            "empty_param": [""],
+        }
+        soar.get("rest/version")
+        soar.delete("rest/containers/1/artifacts/2")
+        return WebhookResponse.text_response("Webhook received!")
+
+    response = app_with_asset_webhook.handle_webhook(
+        method="GET",
+        headers={},
+        path_parts=["test_webhook_with_query"],
+        query={
+            "string_param": "value",
+            "list_param": ["value1", "value2"],
+            "empty_param": None,
+        },
+        body=None,
+        asset={"base_url": "https://example.com"},
+        soar_rest_client=SoarRestClient(token="test_token", asset_id=1),
+    )
+    assert mock_get_any_soar_call.call_count == 2
+    assert mock_delete_any_soar_call.call_count == 1
+    assert response["status_code"] == 200
+    assert response["content"] == "Webhook received!"
 
 
 def test_create_soar_client_auth_object(auth_action_input):


### PR DESCRIPTION
- Allow passing the soar client to the webhooks handler
- Webhooks and actions use the same handler defined in app.py
- Changed app_cli_runner to call handle_webhook instead of the router directly so that the soar_client can be passed to the handler when run through the cli
- Added an asset_id argument for the webhooks sub parser