### PR TITLE
feat(webhooks): catalogue the declared webhook routes in the manifest.json

### DIFF
--- a/src/soar_sdk/cli/path_utils.py
+++ b/src/soar_sdk/cli/path_utils.py
@@ -32,3 +32,10 @@ def context_directory(path: Path) -> Iterator[None]:
             yield
     finally:
         os.chdir(original_dir)
+
+
+def relative_to_cwd(path: Path) -> str:
+    """
+    Get the path relative to the current working directory.
+    """
+    return path.relative_to(Path.cwd()).as_posix()

--- a/src/soar_sdk/meta/webhooks.py
+++ b/src/soar_sdk/meta/webhooks.py
@@ -3,11 +3,23 @@ from ipaddress import ip_network
 from typing import Optional
 
 
+class WebhookRouteMeta(BaseModel):
+    """
+    Metadata for a webhook route, including the handler function and its properties.
+    """
+
+    url_pattern: str
+    allowed_methods: list[str] = Field(default_factory=lambda: ["GET", "POST"])
+    declaration_path: Optional[str] = None
+    declaration_lineno: Optional[int] = None
+
+
 class WebhookMeta(BaseModel):
     handler: Optional[str]
     requires_auth: bool = True
     allowed_headers: list[str] = Field(default_factory=list)
     ip_allowlist: list[str] = Field(default_factory=lambda: ["0.0.0.0/0", "::/0"])
+    routes: list[WebhookRouteMeta] = Field(default_factory=list)
 
     @validator("ip_allowlist", each_item=True)
     def validate_ip_allowlist(cls, value: str) -> str:

--- a/src/soar_sdk/webhooks/routing.py
+++ b/src/soar_sdk/webhooks/routing.py
@@ -79,7 +79,13 @@ class Router(Generic[AssetType]):
 
         # Add route
         self._routes.append(
-            Route(pattern, regex_pattern, methods, handler, param_indices)
+            Route(
+                pattern,
+                regex_pattern,
+                methods,
+                handler,
+                param_indices,
+            )
         )
 
     def handle_request(self, request: WebhookRequest[AssetType]) -> WebhookResponse:

--- a/tests/example_app_with_webhook/app.json
+++ b/tests/example_app_with_webhook/app.json
@@ -28,6 +28,36 @@
     "ip_allowlist": [
       "0.0.0.0/0",
       "::/0"
+    ],
+    "routes": [
+      {
+        "allowed_methods": [
+          "GET",
+          "POST"
+        ],
+        "declaration_lineno": 60,
+        "declaration_path": "src/app.py",
+        "url_pattern": "test_webhook"
+      },
+      {
+        "allowed_methods": [
+          "GET",
+          "POST",
+          "DELETE"
+        ],
+        "declaration_lineno": 72,
+        "declaration_path": "src/app.py",
+        "url_pattern": "test_webhook/<asset_id>"
+      },
+      {
+        "allowed_methods": [
+          "GET",
+          "POST"
+        ],
+        "declaration_lineno": 85,
+        "declaration_path": "src/app.py",
+        "url_pattern": "test_webhook_file"
+      }
     ]
   },
   "configuration": {

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -90,6 +90,7 @@ def test_enable_webhooks(app_with_simple_asset: App):
         "requires_auth": False,
         "allowed_headers": ["Authorization", "X-Forwarded-For"],
         "ip_allowlist": ["10.0.0.0/24"],
+        "routes": [],
     }
 
 


### PR DESCRIPTION
Adding some metadata to the app manifest.json, which catalogues each declared webhook route, with its:
- Path pattern
- Allowed HTTP methods
- Python source file path and line number of the `@app.webhook` decorator

In a platform change as part of this same ticket, we will import this metadata into the database and use it to display the paths/methods on the webhook config page.

In a future update that is not yet prioritized, we will use the source file information to deliver several enhancements to the in-product App Wizard.