### PR TITLE
fix: handle asset decryption properly

### DIFF
--- a/src/soar_sdk/app.py
+++ b/src/soar_sdk/app.py
@@ -10,6 +10,9 @@ from soar_sdk.compat import (
     PythonVersion,
 )
 from soar_sdk.shims.phantom_common.app_interface.app_interface import SoarRestClient
+from soar_sdk.shims.phantom_common.encryption.encryption_manager_factory import (
+    platform_encryption_backend,
+)
 from soar_sdk.abstract import SOARClient, SOARClientAuth
 from soar_sdk.action_results import ActionResult
 from soar_sdk.actions_manager import ActionsManager
@@ -23,7 +26,6 @@ from soar_sdk.types import Action
 from soar_sdk.webhooks.routing import Router
 from soar_sdk.webhooks.models import WebhookRequest, WebhookResponse
 from soar_sdk.exceptions import ActionRegistrationError
-from soar_sdk.crypto import decrypt
 
 import uuid
 from soar_sdk.decorators import (
@@ -151,8 +153,8 @@ class App:
         asset_id = input_data.asset_id
         for field in self.asset_cls.fields_requiring_decryption():
             if field in self._raw_asset_config:
-                self._raw_asset_config[field] = decrypt(
-                    self._raw_asset_config[field], asset_id
+                self._raw_asset_config[field] = platform_encryption_backend.decrypt(
+                    self._raw_asset_config[field], str(asset_id)
                 )
 
         self.__logger.handler.set_handle(handle)

--- a/src/soar_sdk/app_cli_runner.py
+++ b/src/soar_sdk/app_cli_runner.py
@@ -22,8 +22,8 @@ if typing.TYPE_CHECKING:
 
 
 class AppCliRunner:
-    """
-    Runner for local run of the actions handling with the app.
+    """Runner for local run of the actions handling with the app.
+
     Generates subparsers for each action, which take in JSON files for parameters and assets.
     """
 
@@ -31,6 +31,7 @@ class AppCliRunner:
         self.app = app
 
     def parse_args(self, argv: Optional[list[str]] = None) -> argparse.Namespace:
+        """Parse command line arguments for the app CLI runner."""
         root_parser = argparse.ArgumentParser()
         root_parser.add_argument(
             "--soar-url",
@@ -254,6 +255,7 @@ class AppCliRunner:
         print(f"Parsed webhook request: {args.webhook_request}")
 
     def run(self) -> None:
+        """Run the app CLI."""
         args = self.parse_args()
 
         logger = PhantomLogger()

--- a/src/soar_sdk/app_cli_runner.py
+++ b/src/soar_sdk/app_cli_runner.py
@@ -9,13 +9,14 @@ from pydantic import ValidationError
 from urllib.parse import urlparse, parse_qs
 
 from soar_sdk.input_spec import ActionParameter, AppConfig, InputSpecification, SoarAuth
+from soar_sdk.shims.phantom_common.encryption.encryption_manager_factory import (
+    platform_encryption_backend,
+)
 from soar_sdk.types import Action
 from soar_sdk.webhooks.models import WebhookRequest
 from soar_sdk.logging import PhantomLogger
 from soar_sdk.shims.phantom_common.app_interface.app_interface import SoarRestClient
 from soar_sdk.abstract import SOARClientAuth
-
-from soar_sdk.crypto import encrypt
 
 if typing.TYPE_CHECKING:
     from .app import App
@@ -185,7 +186,9 @@ class AppCliRunner:
         fields_to_encrypt = self.app.asset_cls.fields_requiring_decryption()
         for field, value in asset_json.items():
             if field in fields_to_encrypt:
-                asset_json[field] = encrypt(value, input_data.asset_id)
+                asset_json[field] = platform_encryption_backend.encrypt(
+                    value, str(input_data.asset_id)
+                )
 
         input_data.config = AppConfig(
             **input_data.config.dict(),

--- a/src/soar_sdk/asset.py
+++ b/src/soar_sdk/asset.py
@@ -229,3 +229,17 @@ class BaseAsset(BaseModel):
             params[field_name] = params_field
 
         return params
+
+    @classmethod
+    def fields_requiring_decryption(cls) -> set[str]:
+        """Set of fields that require decryption.
+
+        Returns:
+            A set of field names that are marked as sensitive and need
+            decryption before use.
+        """
+        return {
+            field_name
+            for field_name, field in cls.__fields__.items()
+            if field.field_info.extra.get("sensitive", False)
+        }

--- a/src/soar_sdk/shims/phantom_common/encryption/encryption_manager_factory.py
+++ b/src/soar_sdk/shims/phantom_common/encryption/encryption_manager_factory.py
@@ -1,0 +1,25 @@
+try:
+    from phantom_common.encryption.encryption_manager_factory import (
+        platform_encryption_backend,
+    )
+
+    _soar_is_available = True
+except ImportError:
+    _soar_is_available = False
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING or not _soar_is_available:
+    from soar_sdk.shims.phantom.encryption_helper import encryption_helper
+
+    class MockEncryptionBackend:
+        def encrypt(self, plain: str, salt: str) -> str:
+            return encryption_helper.encrypt(plain, salt)
+
+        def decrypt(self, cipher: str, salt: str) -> str:
+            return encryption_helper.decrypt(cipher, salt)
+
+    platform_encryption_backend = MockEncryptionBackend()
+
+
+__all__ = ["platform_encryption_backend"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,12 +13,10 @@ from soar_sdk.input_spec import (
     AppConfig,
     InputSpecification,
     SoarAuth,
-    AppConfigParameter,
 )
 from soar_sdk.action_results import ActionOutput
 from soar_sdk.meta.dependencies import UvWheel
 from soar_sdk.webhooks.models import WebhookRequest, WebhookResponse
-from soar_sdk.crypto import encrypt
 from tests.stubs import SampleActionParams
 from pathlib import Path
 from httpx import Response
@@ -236,16 +234,8 @@ def simple_action_input() -> InputSpecification:
         asset_id="1",
         identifier="test_action",
         action="test_action",
-        app_config={
-            "client_id": AppConfigParameter(data_type="string"),
-            "client_secret": AppConfigParameter(data_type="password"),
-        },
         config=AppConfig(
-            app_version="1.0.0",
-            directory=".",
-            main_module="example_connector.py",
-            client_id="test_client_id",
-            client_secret=encrypt("test_client_secret", "1"),
+            app_version="1.0.0", directory=".", main_module="example_connector.py"
         ),
     )
 

--- a/tests/test_asset.py
+++ b/tests/test_asset.py
@@ -69,3 +69,15 @@ def test_bad_datatype():
 
     with pytest.raises(TypeError, match="Unsupported field type: list"):
         BadDatatype.to_json_schema()
+
+
+def test_fields_requiring_decryption():
+    """
+    Test that fields requiring decryption are correctly identified.
+    """
+
+    class AssetWithSensitiveFields(BaseAsset):
+        sensitive_field: str = AssetField(sensitive=True)
+        normal_field: str = AssetField()
+
+    assert AssetWithSensitiveFields.fields_requiring_decryption() == {"sensitive_field"}


### PR DESCRIPTION
The previous change worked from an invalid assumption about the payload provided to the action handler by spawn. This payload does _not_ contain the types for each asset field, it turns out.

Instead, we will use the asset class as the source of truth for which fields need decrypting. Additionally, when running on the CLI instead of SOAR, we will use a fake encryption_helper to encrypt and decrypt these fields, to match what the handler is expecting.