### PR TITLE
fix: sdk init fix for __init__.py

### DIFF
--- a/src/soar_sdk/cli/init/cli.py
+++ b/src/soar_sdk/cli/init/cli.py
@@ -131,7 +131,7 @@ def init_sdk_app(
     rprint("[blue]Creating app directory structure")
     src_dir = app_dir / "src"
     src_dir.mkdir()
-    (src_dir / "__init__.py").touch()
+    (src_dir / "__init__.py").write_text("from . import app\n\n__ALL__ = [app]\n")
 
     shutil.copy(
         APP_INIT_TEMPLATES / "basic_app/.pre-commit-config.yml",

--- a/tests/example_app/src/__init__.py
+++ b/tests/example_app/src/__init__.py
@@ -1,10 +1,3 @@
-from soar_sdk.compat import remove_when_soar_newer_than
-
-remove_when_soar_newer_than(
-    "6.4.0",
-    "This boilerplate is needed to support webhooks in older SOAR versions. This file can be cleared out now",
-)
-
 from . import app
 
 __ALL__ = [app]

--- a/tests/example_app_with_webhook/src/__init__.py
+++ b/tests/example_app_with_webhook/src/__init__.py
@@ -1,10 +1,3 @@
-from soar_sdk.compat import remove_when_soar_newer_than
-
-remove_when_soar_newer_than(
-    "6.4.0",
-    "This boilerplate is needed to support webhooks in older SOAR versions. This file can be cleared out now",
-)
-
 from . import app
 
 __ALL__ = [app]


### PR DESCRIPTION
- Fix so `__init__.py` after sdk init command contains `from . import app` so custom views will work out of the box