### PR TITLE
feat: allow specifying a custom message with the action output

### DIFF
--- a/docs/api_reference.rst
+++ b/docs/api_reference.rst
@@ -103,6 +103,18 @@ Much like parameters, outputs can have simple data types such as ``str`` or ``in
       uid: int = OutputField(cef_types=["user id"])
       create_date: str
 
+By default, your action will display an "Action completed successfully" message in the SOAR UI. To customize this message, you can override the ``generate_action_summary_message`` method in your output class:
+.. code-block:: python
+
+   from soar_sdk.action_results import ActionOutput
+
+   class CreateUserOutput(ActionOutput):
+      uid: int
+      create_date: str
+
+      def generate_action_summary_message(self) -> str:
+         return f"User created with UID: {self.uid} on {self.create_date}"
+
 Output models can be nested, allowing you to create complex data structures:
 
 .. code-block:: python

--- a/src/soar_sdk/action_results.py
+++ b/src/soar_sdk/action_results.py
@@ -143,6 +143,17 @@ class ActionOutput(BaseModel):
         Nested ActionOutput classes are supported for complex data structures.
     """
 
+    def generate_action_summary_message(self) -> str:
+        """Generate a summary message for the action output.
+
+        This method provides a human-readable summary of the action results,
+        which appears when running the action in a SOAR playbook or container.
+
+        Returns:
+            A string summarizing the action output.
+        """
+        return "Action completed successfully."
+
     @classmethod
     def _to_json_schema(
         cls, parent_datapath: str = "action_result.data.*"

--- a/src/soar_sdk/app.py
+++ b/src/soar_sdk/app.py
@@ -494,7 +494,7 @@ class App:
             param_dict = action_params.dict() if action_params else None
             result = ActionResult(
                 status=True,
-                message="",
+                message=result.generate_action_summary_message(),
                 param=param_dict,
             )
             result.add_data(output_dict)

--- a/src/soar_sdk/shims/phantom/action_result.py
+++ b/src/soar_sdk/shims/phantom/action_result.py
@@ -12,6 +12,7 @@ if TYPE_CHECKING or not _soar_is_available:
     class ActionResult:  # type: ignore[no-redef]
         def __init__(self, param: Optional[dict] = None) -> None:
             self.status = False
+            self.message = ""
 
             if param is None:
                 self.param = {}
@@ -27,6 +28,7 @@ if TYPE_CHECKING or not _soar_is_available:
             _exception: Optional[Exception] = None,
         ) -> bool:
             self.status = bool(status_code)
+            self.message = _status_message
             return self.status
 
         def get_status(self) -> bool:

--- a/tests/example_app/src/actions/reverse_string.py
+++ b/tests/example_app/src/actions/reverse_string.py
@@ -11,6 +11,9 @@ class ReverseStringParams(Params):
 
 
 class ReverseStringOutput(ActionOutput):
+    def generate_action_summary_message(self) -> str:
+        return f"Reversed string: {self.reversed_string}"
+
     original_string: str
     reversed_string: str
 

--- a/tests/test_actions_manager.py
+++ b/tests/test_actions_manager.py
@@ -80,6 +80,38 @@ def test_action_called_with_multiple_results_set(
     assert len(example_app.actions_manager.get_results()) == 3
 
 
+def test_action_called_with_default_message_set(
+    example_app: App, simple_action_input: InputSpecification
+):
+    @example_app.action()
+    def test_action(params: Params) -> ActionOutput:
+        return ActionOutput()
+
+    example_app.handle(simple_action_input.json())
+
+    assert len(example_app.actions_manager.get_results()) == 1
+    assert "success" in example_app.actions_manager.get_results()[0].message
+
+
+def test_action_called_with_custom_message_set(
+    example_app: App, simple_action_input: InputSpecification
+):
+    class CustomActionOutput(ActionOutput):
+        result: int
+
+        def generate_action_summary_message(self) -> str:
+            return f"The result is {self.result}"
+
+    @example_app.action()
+    def test_action(params: Params) -> CustomActionOutput:
+        return CustomActionOutput(result=42)
+
+    example_app.handle(simple_action_input.json())
+
+    assert len(example_app.actions_manager.get_results()) == 1
+    assert example_app.actions_manager.get_results()[0].message == "The result is 42"
+
+
 def test_actions_provider_running_undefined_action(
     example_provider, simple_action_input
 ):


### PR DESCRIPTION
Add an overridable method to the `ActionOutput` base class, which generates the action result message in the SOAR UI. This message can be customized using properties from the output.