### PR TITLE
fix: get custom views to render on analyst widget page

### DIFF
--- a/src/soar_sdk/templates/widgets/widget_resize_snippet.html
+++ b/src/soar_sdk/templates/widgets/widget_resize_snippet.html
@@ -1,5 +1,3 @@
-<!-- widget_resize_snippet.html from platform -->
-
 <li class="tools-menu">
   <table class="widget-sizebox parent-widget-sizebox">
     <tr>

--- a/src/soar_sdk/templates/widgets/widget_template.html
+++ b/src/soar_sdk/templates/widgets/widget_template.html
@@ -1,5 +1,3 @@
-<!-- widget_template.html from platform (modified for Jinja) -->
-
 {% set this_widget_uuid = widget_uuid() %}
 
 <div class="no-padding fill-space {% block extra_classes %}{% endblock %}"


### PR DESCRIPTION
Yeah not fully sure what was going on here but the html comments in the template file were preventing the SDK custom views from getting populated on the analyst dashboard page 💀 

Fixed:
<img width="702" height="357" alt="Screenshot 2025-08-06 at 11 49 09 AM" src="https://github.com/user-attachments/assets/ed990c53-0b67-42d6-a3b2-b9e28d5eea81" />