### PR TITLE
PAPP-36658: generic action decorator for universal API calls

### DIFF
--- a/docs/api_reference.rst
+++ b/docs/api_reference.rst
@@ -26,6 +26,7 @@ Key Methods
 .. automethod:: soar_sdk.app.App.register_action
 .. automethod:: soar_sdk.app.App.enable_webhooks
 .. automethod:: soar_sdk.app.App.view_handler
+.. automethod:: soar_sdk.app.App.generic_action
 
 .. _asset-configuration-label:
 Asset Configuration
@@ -92,6 +93,19 @@ For a full list of Param options, see the ``Params`` class and ``Param`` functio
 
 .. autofunction:: soar_sdk.params.Param
 
+Parameters for on poll
+^^^^^^^^^^^^^^^^^^^^^^
+On poll functions require a specfic paramter class called OnPollParams. You should not override this class and use it as is.
+
+.. autoclass:: soar_sdk.params.OnPollParams
+
+Parameters for generic action
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Generic action functions require a specfic paramter class called GenericActionParams. You should not override this class and use it as is.
+
+.. autoclass:: soar_sdk.params.GenericActionParams
+
+
 .. _action-output-label:
 Action Outputs
 ~~~~~~~~~~~~
@@ -143,6 +157,12 @@ For more details, see the ``ActionOutput`` class and the ``OutputField`` functio
 .. autoclass:: soar_sdk.action_results.ActionOutput
 
 .. autofunction:: soar_sdk.action_results.OutputField
+
+Generic Action Output
+^^^^^^^^^^^^^^^^^^^^^
+For generic action functions we have provided a convinience class called GenericActionOutput. This class extends the ActionOutput class and adds a status_code and response_body field. You can use this class to return the response from the generic action.
+
+.. autoclass:: soar_sdk.action_results.GenericActionOutput
 
 APIs
 ----

--- a/src/soar_sdk/action_results.py
+++ b/src/soar_sdk/action_results.py
@@ -222,3 +222,8 @@ class ActionOutput(BaseModel):
                 schema_field["example_values"] = [True, False]
 
             yield schema_field
+
+
+class GenericActionOutput(ActionOutput):
+    status_code: int = OutputField(example_values=[200, 404, 500])
+    response_body: str = OutputField(example_values=['{"key": "value"}'])

--- a/src/soar_sdk/action_results.py
+++ b/src/soar_sdk/action_results.py
@@ -225,5 +225,19 @@ class ActionOutput(BaseModel):
 
 
 class GenericActionOutput(ActionOutput):
+    """
+    Output class for generic actions.
+
+    This class extends the ActionOutput class and adds a status_code and response_body field. You can use this class as is or extend it to add more fields.
+
+    Example:
+        >>> class CustomGenericActionOutput(GenericActionOutput):
+        ...     error: str = OutputField(example_values=["Invalid credentials"])
+
+    Note:
+        The status_code field is used to return the HTTP status code of the response.
+        The response_body field is used to return the response body of the response.
+    """
+
     status_code: int = OutputField(example_values=[200, 404, 500])
     response_body: str = OutputField(example_values=['{"key": "value"}'])

--- a/src/soar_sdk/app.py
+++ b/src/soar_sdk/app.py
@@ -404,7 +404,9 @@ class App:
         """
         return ViewHandlerDecorator(self, template=template)
 
-    def generic_action(self) -> GenericActionDecorator:
+    def generic_action(
+        self, output_class: Optional[type[ActionOutput]] = None
+    ) -> GenericActionDecorator:
         """Decorator for registering a generic action function.
 
         This decorator marks a function as the generic action for the app. Generic action is used to call any endpoint of the underlying API service this app implements.
@@ -428,7 +430,7 @@ class App:
         Note:
             The generic action function should return either a GenericActionOutput object or an output class derived from ActionOutput/GenericActionOutput.
         """
-        return GenericActionDecorator(self)
+        return GenericActionDecorator(self, output_class=output_class)
 
     @staticmethod
     def _validate_params_class(

--- a/src/soar_sdk/app.py
+++ b/src/soar_sdk/app.py
@@ -407,7 +407,26 @@ class App:
     def generic_action(self) -> GenericActionDecorator:
         """Decorator for registering a generic action function.
 
-        This decorator marks a function as a generic action for the app.
+        This decorator marks a function as the generic action for the app. Generic action is used to call any endpoint of the underlying API service this app implements.
+        Only one generic action is allowed per app. The function you define needs to accept at least one parameter of type GenericActionParams and can accept any other parameters you need.
+        Other useful parameters to accept are the SOARClient and the asset.
+
+        Returns:
+            GenericActionDecorator: A decorator instance that handles generic action registration.
+
+        Example:
+            >>> @app.generic_action()
+            ... def http_action(
+            ...     self, params: GenericActionParams, asset: Asset
+            ... ) -> GenericActionOutput:
+            ...     logger.info(f"testing connectivity against {asset.base_url}")
+            ...     return GenericActionOutput(
+            ...         status_code=200,
+            ...         response_body=f"Base url is {asset.base_url}",
+            ...     )
+
+        Note:
+            The generic action function should return either a GenericActionOutput object or an output class derived from ActionOutput/GenericActionOutput.
         """
         return GenericActionDecorator(self)
 

--- a/src/soar_sdk/app.py
+++ b/src/soar_sdk/app.py
@@ -34,6 +34,7 @@ from soar_sdk.decorators import (
     ViewHandlerDecorator,
     OnPollDecorator,
     WebhookDecorator,
+    GenericActionDecorator,
 )
 
 
@@ -402,6 +403,13 @@ class App:
             ...     )
         """
         return ViewHandlerDecorator(self, template=template)
+
+    def generic_action(self) -> GenericActionDecorator:
+        """Decorator for registering a generic action function.
+
+        This decorator marks a function as a generic action for the app.
+        """
+        return GenericActionDecorator(self)
 
     @staticmethod
     def _validate_params_class(

--- a/src/soar_sdk/decorators/__init__.py
+++ b/src/soar_sdk/decorators/__init__.py
@@ -9,10 +9,12 @@ from .test_connectivity import ConnectivityTestDecorator
 from .view_handler import ViewHandlerDecorator
 from .on_poll import OnPollDecorator
 from .webhook import WebhookDecorator
+from .generic_action import GenericActionDecorator
 
 __all__ = [
     "ActionDecorator",
     "ConnectivityTestDecorator",
+    "GenericActionDecorator",
     "OnPollDecorator",
     "ViewHandlerDecorator",
     "WebhookDecorator",

--- a/src/soar_sdk/decorators/generic_action.py
+++ b/src/soar_sdk/decorators/generic_action.py
@@ -1,0 +1,139 @@
+import inspect
+
+from soar_sdk.abstract import SOARClient
+from soar_sdk.action_results import ActionResult
+from soar_sdk.params import GenericActionParams
+from soar_sdk.meta.actions import ActionMeta
+from soar_sdk.action_results import ActionOutput, GenericActionOutput
+from soar_sdk.types import Action, action_protocol
+from soar_sdk.exceptions import ActionFailure
+from soar_sdk.async_utils import run_async_if_needed
+from soar_sdk.logging import getLogger
+from functools import wraps
+import traceback
+
+from typing import TYPE_CHECKING, Callable, Any, Optional
+
+if TYPE_CHECKING:
+    from soar_sdk.app import App
+
+
+class GenericActionDecorator:
+    """
+    Class-based decorator for generic action functionality.
+    """
+
+    def __init__(
+        self,
+        app: "App",
+        output_class: Optional[type[ActionOutput]] = None,
+    ) -> None:
+        self.app = app
+        self.output_class = output_class
+
+    def __call__(self, function: Callable) -> Action:
+        """
+        Decorator for the generic action.
+
+        The decorated function implements a generic action that can be used to call any endpoint of the underlying API service this app implements.
+
+        Usage:
+        This decorated function automatically gets all the parameters from the GenericActionParams class and passes them to the function. GenericActionParams represents the parameters required for most http requests.
+        You should use your existing asset interface to make this request.
+        """
+
+        if self.app.actions_manager.get_action("generic_action"):
+            raise TypeError(
+                "The 'generic_action' decorator can only be used once per App instance."
+            )
+
+        # Validate function signature - must have at least one parameter of type GenericActionParams
+        signature = inspect.signature(function)
+        params = list(signature.parameters.values())
+
+        if not any(param.annotation == GenericActionParams for param in params):
+            raise TypeError(
+                f"Generic action function must have at least one parameter of type GenericActionParams, got {params[0].annotation}"
+            )
+
+        action_identifier = "generic_action"
+        action_name = "generic action"
+        # for generic action use GenericActionParams
+        validated_params_class = GenericActionParams
+
+        return_type = inspect.signature(function).return_annotation
+        if return_type is not inspect.Signature.empty:
+            validated_output_class = return_type
+        elif self.output_class is not None:
+            validated_output_class = self.output_class
+        else:
+            raise TypeError(
+                "Action function must specify a return type via type hint or output_class parameter"
+            )
+
+        if not issubclass(validated_output_class, ActionOutput) and not isinstance(
+            validated_output_class, GenericActionOutput
+        ):
+            raise TypeError(
+                "Return type for action function must be either GenericActionOutput or derived from ActionOutput or GenericActionOutput class."
+            )
+
+        logger = getLogger()
+
+        @action_protocol
+        @wraps(function)
+        def inner(
+            params: GenericActionParams,
+            soar: SOARClient = self.app.soar_client,
+            *args: Any,  # noqa: ANN401
+            **kwargs: Any,  # noqa: ANN401
+        ) -> bool:
+            try:
+                action_params = validated_params_class.parse_obj(params)
+            except Exception as e:
+                logger.info(f"Parameter validation error: {e!s}")
+                return self.app._adapt_action_result(
+                    ActionResult(status=False, message=f"Invalid parameters: {e!s}"),
+                    self.app.actions_manager,
+                )
+            kwargs = self.app._build_magic_args(function, soar=soar, **kwargs)
+
+            try:
+                result = function(action_params, *args, **kwargs)
+                result = run_async_if_needed(result)
+            except ActionFailure as e:
+                e.set_action_name(action_name)
+                return self.app._adapt_action_result(
+                    ActionResult(status=False, message=str(e)),
+                    self.app.actions_manager,
+                )
+            except Exception as e:
+                self.app.actions_manager.add_exception(e)
+                traceback_str = "".join(
+                    traceback.format_exception(type(e), e, e.__traceback__)
+                )
+                return self.app._adapt_action_result(
+                    ActionResult(status=False, message=traceback_str),
+                    self.app.actions_manager,
+                )
+
+            return self.app._adapt_action_result(
+                result, self.app.actions_manager, action_params
+            )
+
+        inner.params_class = validated_params_class
+        inner.meta = ActionMeta(
+            action=action_name,
+            identifier=action_identifier,
+            description=inspect.getdoc(function) or action_name,
+            verbose="Generic action for the app.",
+            type="generic",
+            parameters=validated_params_class,
+            output=validated_output_class,
+            read_only=False,
+            versions="EQ(*)",
+        )
+
+        self.app.actions_manager.set_action(action_identifier, inner)
+        self.app._dev_skip_in_pytest(function, inner)
+        return inner

--- a/src/soar_sdk/params.py
+++ b/src/soar_sdk/params.py
@@ -189,18 +189,18 @@ class GenericActionParams(Params):
         required=True,
     )
 
-    headers: dict[str, str] = Param(
-        description="The headers to send with the request.",
+    headers: str = Param(
+        description="The headers to send with the request (JSON object).",
         required=False,
     )
 
-    query_params: dict[str, str] = Param(
-        description="The query parameters to send with the request.",
+    query_params: str = Param(
+        description="The query string to send with the request.",
         required=False,
     )
 
-    body: dict[str, Any] = Param(
-        description="The body to send with the request.",
+    body: str = Param(
+        description="The body to send with the request (JSON object).",
         required=False,
     )
 

--- a/src/soar_sdk/params.py
+++ b/src/soar_sdk/params.py
@@ -176,6 +176,8 @@ class OnPollParams(Params):
 class GenericActionParams(Params):
     """
     Parameters for generic actions.
+
+    Used to define the specific parameters for the generic action.
     """
 
     http_method: str = Param(

--- a/src/soar_sdk/params.py
+++ b/src/soar_sdk/params.py
@@ -171,3 +171,45 @@ class OnPollParams(Params):
         required=False,
         allow_list=True,
     )
+
+
+class GenericActionParams(Params):
+    """
+    Parameters for generic actions.
+    """
+
+    http_method: str = Param(
+        description="The HTTP method to use for the request.",
+        required=True,
+        value_list=["GET", "POST", "PUT", "DELETE", "PATCH", "HEAD", "OPTIONS"],
+    )
+
+    endpoint: str = Param(
+        description="The endpoint to send the request to.",
+        required=True,
+    )
+
+    headers: dict[str, str] = Param(
+        description="The headers to send with the request.",
+        required=False,
+    )
+
+    query_params: dict[str, str] = Param(
+        description="The query parameters to send with the request.",
+        required=False,
+    )
+
+    body: dict[str, Any] = Param(
+        description="The body to send with the request.",
+        required=False,
+    )
+
+    timeout: int = Param(
+        description="The timeout for the request.",
+        required=False,
+    )
+
+    verify_ssl: bool = Param(
+        description="Whether to verify the SSL certificate.",
+        required=False,
+    )

--- a/tests/example_app/app.json
+++ b/tests/example_app/app.json
@@ -177,6 +177,147 @@
             }
         },
         {
+            "action": "generic action",
+            "identifier": "generic_action",
+            "description": "generic action",
+            "type": "generic",
+            "read_only": false,
+            "versions": "EQ(*)",
+            "verbose": "Generic action for the app.",
+            "parameters": {
+                "http_method": {
+                    "order": 0,
+                    "name": "http_method",
+                    "description": "The HTTP method to use for the request.",
+                    "data_type": "string",
+                    "required": true,
+                    "primary": false,
+                    "allow_list": false,
+                    "value_list": [
+                        "GET",
+                        "POST",
+                        "PUT",
+                        "DELETE",
+                        "PATCH",
+                        "HEAD",
+                        "OPTIONS"
+                    ]
+                },
+                "endpoint": {
+                    "order": 1,
+                    "name": "endpoint",
+                    "description": "The endpoint to send the request to.",
+                    "data_type": "string",
+                    "required": true,
+                    "primary": false,
+                    "allow_list": false
+                },
+                "headers": {
+                    "order": 2,
+                    "name": "headers",
+                    "description": "The headers to send with the request (JSON object).",
+                    "data_type": "string",
+                    "required": false,
+                    "primary": false,
+                    "allow_list": false
+                },
+                "query_params": {
+                    "order": 3,
+                    "name": "query_params",
+                    "description": "The query string to send with the request.",
+                    "data_type": "string",
+                    "required": false,
+                    "primary": false,
+                    "allow_list": false
+                },
+                "body": {
+                    "order": 4,
+                    "name": "body",
+                    "description": "The body to send with the request (JSON object).",
+                    "data_type": "string",
+                    "required": false,
+                    "primary": false,
+                    "allow_list": false
+                },
+                "timeout": {
+                    "order": 5,
+                    "name": "timeout",
+                    "description": "The timeout for the request.",
+                    "data_type": "numeric",
+                    "required": false,
+                    "primary": false,
+                    "allow_list": false
+                },
+                "verify_ssl": {
+                    "order": 6,
+                    "name": "verify_ssl",
+                    "description": "Whether to verify the SSL certificate.",
+                    "data_type": "boolean",
+                    "required": false,
+                    "primary": false,
+                    "allow_list": false
+                }
+            },
+            "output": [
+                {
+                    "data_path": "action_result.status",
+                    "data_type": "string",
+                    "example_values": [
+                        "success",
+                        "failure"
+                    ]
+                },
+                {
+                    "data_path": "action_result.message",
+                    "data_type": "string"
+                },
+                {
+                    "data_path": "action_result.parameter.http_method",
+                    "data_type": "string"
+                },
+                {
+                    "data_path": "action_result.parameter.endpoint",
+                    "data_type": "string"
+                },
+                {
+                    "data_path": "action_result.parameter.headers",
+                    "data_type": "string"
+                },
+                {
+                    "data_path": "action_result.parameter.query_params",
+                    "data_type": "string"
+                },
+                {
+                    "data_path": "action_result.parameter.body",
+                    "data_type": "string"
+                },
+                {
+                    "data_path": "action_result.parameter.timeout",
+                    "data_type": "numeric"
+                },
+                {
+                    "data_path": "action_result.parameter.verify_ssl",
+                    "data_type": "boolean"
+                },
+                {
+                    "data_path": "action_result.data.*.status_code",
+                    "data_type": "numeric",
+                    "example_values": [
+                        200,
+                        404,
+                        500
+                    ]
+                },
+                {
+                    "data_path": "action_result.data.*.response_body",
+                    "data_type": "string",
+                    "example_values": [
+                        "{\"key\": \"value\"}"
+                    ]
+                }
+            ]
+        },
+        {
             "action": "on poll",
             "identifier": "on_poll",
             "description": "on poll",

--- a/tests/example_app/src/app.py
+++ b/tests/example_app/src/app.py
@@ -4,10 +4,11 @@ from datetime import datetime, timezone
 from soar_sdk.abstract import SOARClient
 from soar_sdk.app import App
 from soar_sdk.asset import AssetField, BaseAsset
-from soar_sdk.params import OnPollParams
+from soar_sdk.params import OnPollParams, GenericActionParams
 from soar_sdk.models.container import Container
 from soar_sdk.models.artifact import Artifact
 from soar_sdk.logging import getLogger
+from soar_sdk.action_results import GenericActionOutput
 
 logger = getLogger()
 
@@ -63,6 +64,11 @@ app.register_action(
     verbose="Generate statistics with pie chart reusable component.",
     view_handler=render_statistics_chart,
 )
+
+
+@app.generic_action()
+def http_action(params: GenericActionParams) -> GenericActionOutput:
+    logger.info(f"HTTP action triggered with params: {params}")
 
 
 @app.on_poll()

--- a/tests/example_app/src/app.py
+++ b/tests/example_app/src/app.py
@@ -67,8 +67,12 @@ app.register_action(
 
 
 @app.generic_action()
-def http_action(params: GenericActionParams) -> GenericActionOutput:
+def http_action(params: GenericActionParams, asset: Asset) -> GenericActionOutput:
     logger.info(f"HTTP action triggered with params: {params}")
+    return GenericActionOutput(
+        status_code=200,
+        response_body=f"Base url is {asset.base_url}",
+    )
 
 
 @app.on_poll()

--- a/tests/test_generic_action.py
+++ b/tests/test_generic_action.py
@@ -1,0 +1,165 @@
+import pytest
+from soar_sdk.abstract import SOARClient
+from soar_sdk.action_results import GenericActionOutput, OutputField
+from unittest import mock
+from soar_sdk.app import App
+from soar_sdk.params import GenericActionParams, Params
+from soar_sdk.exceptions import ActionFailure
+from soar_sdk.asset import BaseAsset
+
+
+class ValidAsset(BaseAsset):
+    normal_field: str
+    another_field: int
+
+
+def test_generic_action_decoration_fails_when_used_more_than_once(app_with_action: App):
+    @app_with_action.generic_action()
+    def http_action(params: GenericActionParams) -> GenericActionOutput:
+        pass
+
+    with pytest.raises(TypeError) as exception_info:
+
+        @app_with_action.generic_action()
+        def http_action2(params: GenericActionParams) -> GenericActionOutput:
+            pass
+
+    assert (
+        "The 'generic_action' decorator can only be used once per App instance."
+        in str(exception_info)
+    )
+
+
+def test_generic_action_decoration(app_with_action: App):
+    @app_with_action.generic_action()
+    def http_action(params: GenericActionParams) -> GenericActionOutput:
+        """
+        This action does nothing for now.
+        """
+        return GenericActionOutput(
+            status_code=200,
+            response_body="Hello, world!",
+        )
+
+    app_with_action.actions_manager = mock.Mock()
+    result = http_action(params=GenericActionParams(http_method="GET", endpoint="/"))
+    assert result
+    assert app_with_action.actions_manager.add_result.call_count == 1
+
+
+def test_generic_action_without_generic_action_params(app_with_action: App):
+    with pytest.raises(TypeError) as exception_info:
+
+        @app_with_action.generic_action()
+        def http_action(client: SOARClient) -> GenericActionOutput:
+            pass
+
+    assert (
+        "Generic action function must have at least one parameter of type GenericActionParams, got <class 'soar_sdk.abstract.SOARClient'>"
+        in str(exception_info)
+    )
+
+    with pytest.raises(TypeError) as exception_info:
+
+        @app_with_action.generic_action()
+        def http_action(params: Params, client: SOARClient) -> GenericActionOutput:
+            pass
+
+    assert (
+        "Generic action function must have at least one parameter of type GenericActionParams, got <class 'soar_sdk.params.Params'>"
+        in str(exception_info)
+    )
+
+
+def test_invalid_output_type(app_with_action: App):
+    with pytest.raises(TypeError) as exception_info:
+
+        @app_with_action.generic_action()
+        def http_action(params: GenericActionParams) -> str:
+            pass
+
+    assert (
+        "Return type for action function must be either GenericActionOutput or derived from ActionOutput or GenericActionOutput class."
+        in str(exception_info)
+    )
+
+
+def test_generic_action_output_class(app_with_action: App):
+    class CustomGenericActionOutput(GenericActionOutput):
+        error: str = OutputField(example_values=["Invalid credentials"])
+
+    @app_with_action.generic_action(output_class=CustomGenericActionOutput)
+    def http_action(params: GenericActionParams, asset: ValidAsset):
+        return CustomGenericActionOutput(
+            status_code=401,
+            response_body="Invalid credentials",
+            error="Invalid credentials",
+        )
+
+    app_with_action.actions_manager = mock.Mock()
+    result = http_action(
+        params=GenericActionParams(http_method="GET", endpoint="/"),
+        asset=ValidAsset(normal_field="test", another_field=42),
+    )
+    assert result
+    assert app_with_action.actions_manager.add_result.call_count == 1
+
+
+def test_no_output_class(app_with_action: App):
+    with pytest.raises(TypeError) as exception_info:
+
+        @app_with_action.generic_action()
+        def http_action(params: GenericActionParams):
+            pass
+
+    assert (
+        "Action function must specify a return type via type hint or output_class parameter"
+        in str(exception_info)
+    )
+
+
+def test_parameter_validation_error(app_with_action: App):
+    """Test that parameter validation errors are handled properly (lines 93-95)"""
+
+    @app_with_action.generic_action()
+    def http_action(params: GenericActionParams) -> GenericActionOutput:
+        return GenericActionOutput(status_code=200, response_body="OK")
+
+    app_with_action.actions_manager = mock.Mock()
+
+    invalid_params = "invalid"
+
+    result = http_action(params=invalid_params)
+
+    assert result is False
+    assert app_with_action.actions_manager.add_result.call_count == 1
+
+
+def test_generic_action_raises_exception_propagates(app_with_action: App):
+    """Test that exceptions raised in the generic action function are handled and return False."""
+
+    @app_with_action.generic_action()
+    def http_action(params: GenericActionParams, client=None) -> GenericActionOutput:
+        raise ValueError("error")
+        return GenericActionOutput(status_code=200, response_body="OK")
+
+    client_mock = mock.Mock()
+
+    result = http_action(
+        params=GenericActionParams(http_method="GET", endpoint="/"), client=client_mock
+    )
+    assert result is False
+
+
+def test_generic_action_raises_action_failure_propagates(app_with_action: App):
+    @app_with_action.generic_action()
+    def http_action(
+        params: GenericActionParams, asset: ValidAsset
+    ) -> GenericActionOutput:
+        raise ActionFailure("error")
+
+    result = http_action(
+        params=GenericActionParams(http_method="GET", endpoint="/"),
+        asset=ValidAsset(normal_field="test", another_field=42),
+    )
+    assert result is False


### PR DESCRIPTION
- The generic action decorator can be used to define an action which accepts basic http parameters that will allow the user to query the underlying API service the app implements.
- example run: https://ssc-cicd-sanity-tests.soar.stg.splunkcloud.com/mission/166696/analyst/action_run/432275