### PR TITLE
feat: support timezone type for asset parameters

### DIFF
--- a/src/soar_sdk/app.py
+++ b/src/soar_sdk/app.py
@@ -2,6 +2,7 @@ import inspect
 import json
 import sys
 from typing import Any, Optional, Union, Callable
+from zoneinfo import ZoneInfo
 
 from soar_sdk.asset import BaseAsset
 from soar_sdk.input_spec import InputSpecification
@@ -157,6 +158,11 @@ class App:
                 self._raw_asset_config[field] = platform_encryption_backend.decrypt(
                     self._raw_asset_config[field], str(asset_id)
                 )
+
+        # Inflate timezone fields in the asset configuration
+        for field in self.asset_cls.timezone_fields():
+            if field in self._raw_asset_config:
+                self._raw_asset_config[field] = ZoneInfo(self._raw_asset_config[field])
 
         self.__logger.handler.set_handle(handle)
         soar_auth = App.create_soar_client_auth_object(input_data)

--- a/src/soar_sdk/code_renderers/app_renderer.py
+++ b/src/soar_sdk/code_renderers/app_renderer.py
@@ -5,8 +5,7 @@ from collections.abc import Iterator
 
 
 def create_default_asset_cls() -> ast.ClassDef:
-    """
-    Create a default Asset class definition.
+    """Create a default Asset class definition.
 
     Returns:
         ast.ClassDef: The AST node representing the Asset class.
@@ -22,6 +21,8 @@ def create_default_asset_cls() -> ast.ClassDef:
 
 @dataclasses.dataclass
 class AppContext:
+    """Represents the context for rendering an app's Python code."""
+
     name: str
     app_type: str
     logo: str
@@ -38,13 +39,10 @@ class AppContext:
 
 
 class AppRenderer:
-    """
-    A class to render an app.py module using ASTs.
-    """
+    """A class to render an app.py module using ASTs."""
 
     def __init__(self, context: AppContext) -> None:
-        """
-        Initialize the AppRenderer with the given context.
+        """Initialize the AppRenderer with the given context.
 
         Args:
             context (AppContext): The context containing app details.
@@ -53,8 +51,7 @@ class AppRenderer:
 
     @staticmethod
     def create_default_imports() -> Iterator[Union[ast.Import, ast.ImportFrom]]:
-        """
-        Create default imports for the App module.
+        """Create default imports for the App module.
 
         Returns:
             Iterator[ast.Import]: An iterator of Import nodes.
@@ -66,6 +63,9 @@ class AppRenderer:
             module="collections.abc",
             names=[ast.alias(name="Iterator", asname=None)],
             level=0,
+        )
+        yield ast.ImportFrom(
+            module="zoneinfo", names=[ast.alias(name="ZoneInfo", asname=None)], level=0
         )
         yield ast.ImportFrom(
             module="soar_sdk.abstract",
@@ -117,8 +117,7 @@ class AppRenderer:
         )
 
     def create_app_constructor(self) -> ast.Assign:
-        """
-        Create the App class constructor.
+        """Create the App class constructor.
 
         Returns:
             ast.Assign: The AST node representing the App class instantiation.
@@ -171,8 +170,7 @@ class AppRenderer:
 
     @staticmethod
     def create_main_check() -> ast.If:
-        """
-        Create the main check for the App module.
+        """Create the main check for the App module.
 
         Returns:
             ast.If: The AST node representing the main check.
@@ -200,8 +198,7 @@ class AppRenderer:
         )
 
     def render(self) -> ast.Module:
-        """
-        Render the App module.
+        """Render the App module.
 
         Returns:
             ast.module: The rendered content for the App class.

--- a/src/soar_sdk/code_renderers/asset_renderer.py
+++ b/src/soar_sdk/code_renderers/asset_renderer.py
@@ -9,9 +9,7 @@ from soar_sdk.meta.datatypes import to_python_type
 
 @dataclasses.dataclass
 class AssetContext:
-    """
-    Context for rendering individual configuration keys of an Asset class.
-    """
+    """Context for rendering individual configuration keys of an Asset class."""
 
     name: str
     description: Optional[str]
@@ -22,8 +20,7 @@ class AssetContext:
 
     @property
     def is_str(self) -> bool:
-        """
-        Check if the type is a string.
+        """Check if the type is a string.
 
         Returns:
             bool: True if the type is str, False otherwise.
@@ -32,8 +29,7 @@ class AssetContext:
 
     @property
     def py_type(self) -> str:
-        """
-        Get the Python type of the asset field.
+        """Get the Python type of the asset field.
 
         Returns:
             type: The Python type of the asset field.
@@ -42,13 +38,10 @@ class AssetContext:
 
 
 class AssetRenderer(AstRenderer[list[AssetContext]]):
-    """
-    A class to render an app's Asset class using Jinja2 templates.
-    """
+    """A class to render an app's Asset class using Jinja2 templates."""
 
     def render_ast(self) -> Iterator[ast.stmt]:
-        """
-        Render the Asset class by building an AST.
+        """Render the Asset class by building an AST.
 
         Returns:
             str: The rendered code for the Asset class.
@@ -75,12 +68,24 @@ class AssetRenderer(AstRenderer[list[AssetContext]]):
                     )
                 )
             if field.default is not None:
-                field_kwargs.append(
-                    ast.keyword(
-                        arg="default",
-                        value=ast.Constant(value=field.default),
+                if field.data_type == "timezone":
+                    field_kwargs.append(
+                        ast.keyword(
+                            arg="default",
+                            value=ast.Call(
+                                func=ast.Name(id="ZoneInfo", ctx=ast.Load()),
+                                args=[ast.Constant(value=field.default)],
+                                keywords=[],
+                            ),
+                        )
                     )
-                )
+                else:
+                    field_kwargs.append(
+                        ast.keyword(
+                            arg="default",
+                            value=ast.Constant(value=field.default),
+                        )
+                    )
             if field.value_list is not None:
                 field_kwargs.append(
                     ast.keyword(

--- a/src/soar_sdk/meta/datatypes.py
+++ b/src/soar_sdk/meta/datatypes.py
@@ -1,14 +1,21 @@
+from zoneinfo import ZoneInfo
+
+
 def as_datatype(t: type) -> str:
+    """Convert a Python type to a SOAR data type string."""
     if t is str:
         return "string"
     elif t in (int, float):
         return "numeric"
     elif t is bool:
         return "boolean"
+    elif t is ZoneInfo:
+        return "timezone"
     raise TypeError(f"Unsupported field type: {t.__name__}")
 
 
 def to_python_type(datatype: str) -> type:
+    """Convert a SOAR data type string to a Python type."""
     datatype = datatype.lower()
     if datatype in ("string", "password", "file"):
         return str
@@ -16,4 +23,6 @@ def to_python_type(datatype: str) -> type:
         return float
     if datatype == "boolean":
         return bool
+    if datatype == "timezone":
+        return ZoneInfo
     raise TypeError(f"Unsupported datatype: {datatype}")

--- a/tests/cli/test_convert_cli.py
+++ b/tests/cli/test_convert_cli.py
@@ -62,6 +62,12 @@ def test_generate_asset_definition(app_meta, tmp_path):
             default="blue",
             value_list=["red", "green", "blue"],
         ),
+        "timezone": AssetFieldSpecification(
+            label="Timezone",
+            required=False,
+            data_type="timezone",
+            default="UTC",
+        ),
     }
     asset_class = cli.generate_asset_definition_ast(app_meta=app_meta)
 
@@ -71,6 +77,7 @@ def test_generate_asset_definition(app_meta, tmp_path):
             "class Asset(BaseAsset):",
             "    username: str = AssetField(required=True, description='The username for the application')",
             "    color: str = AssetField(required=False, default='blue', value_list=['red', 'green', 'blue'])",
+            "    timezone: ZoneInfo = AssetField(required=False, default=ZoneInfo('UTC'))",
         ]
     )
 

--- a/tests/example_app/app.json
+++ b/tests/example_app/app.json
@@ -45,6 +45,19 @@
                 "Authorization",
                 "X-API-Key"
             ]
+        },
+        "timezone": {
+            "data_type": "timezone",
+            "required": true,
+            "description": "Timezone",
+            "order": 3
+        },
+        "timezone_with_default": {
+            "data_type": "timezone",
+            "required": true,
+            "description": "Timezone With Default",
+            "order": 4,
+            "default": "America/Denver"
         }
     },
     "actions": [

--- a/tests/example_app/src/app.py
+++ b/tests/example_app/src/app.py
@@ -1,6 +1,7 @@
 from typing import Union
 from collections.abc import Iterator
 from datetime import datetime, timezone
+from zoneinfo import ZoneInfo
 from soar_sdk.abstract import SOARClient
 from soar_sdk.app import App
 from soar_sdk.asset import AssetField, BaseAsset
@@ -21,6 +22,8 @@ class Asset(BaseAsset):
         value_list=["Authorization", "X-API-Key"],
         description="Header for API key authentication",
     )
+    timezone: ZoneInfo
+    timezone_with_default: ZoneInfo = AssetField(default=ZoneInfo("America/Denver"))
 
 
 app = App(
@@ -122,7 +125,6 @@ app.register_action(
     action_type="investigate",
     verbose="Processes a message synchronously with sequential HTTP requests.",
 )
-
 
 if __name__ == "__main__":
     app.cli()


### PR DESCRIPTION
## Features
List any new features you've added to the SDK:
 - Implement the `timezone` type for asset configuration parameters. This is expressed using the `zoneinfo.ZoneInfo` type from Python's standard library.

## Pull Request Checklist
 - [x] I have added or updated unit tests where appropriate.
 - [x] I have updated documentation and example apps where appropriate.
 - [x] My commit messages adhere to the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard.
 - [x] All GitHub Actions and Pre-Commit checks have completed successfully.

## Legal Notice

By submitting a Contribution to this Work, You agree that Your Contribution is made subject to the primary license in the Apache 2.0 license (https://www.apache.org/licenses/LICENSE-2.0.txt). In addition, You represent that: (i) You are the copyright owner of the Contribution or (ii) You have the requisite rights to make the Contribution.

### Definitions:

"You" shall mean: (i) yourself if you are making a Contribution on your own behalf; or (ii) your company, if you are making a Contribution on behalf of your company. If you are making a Contribution on behalf of your company, you represent that you have the requisite authority to do so.

"Contribution" shall mean any original work of authorship, including any modifications or additions to an existing work, that is intentionally submitted by You for inclusion in, or documentation of, this project/repository. For the purposes of this definition, "submitted" means any form of electronic, verbal, or written communication submitted for inclusion in this project/repository, including but not limited to communication on electronic mailing lists, source code control systems, and issue tracking systems that are managed by, or on behalf of, the maintainers of the project/repository.

"Work" shall mean the collective software, content, and documentation in this project/repository.
