### PR TITLE
fix: use field aliases for serializing outputs when available

### DIFF
--- a/src/soar_sdk/action_results.py
+++ b/src/soar_sdk/action_results.py
@@ -137,6 +137,10 @@ class ActionOutput(BaseModel):
         ...     )
         ...     port: int = OutputField(example_values=[80, 443, 8080])
         ...     is_secure: bool  # Automatically gets True/False examples
+        ...
+        ...     under_field: str = OutputField(
+        ...         alias="_under_field"
+        ...     )  # Model fields can't start with an underscore, so we're using an alias to create the proper JSON key
 
     Note:
         Fields cannot be Union or Optional types. Use specific types only.
@@ -180,7 +184,9 @@ class ActionOutput(BaseModel):
             Nested ActionOutput classes are recursively processed.
             Boolean fields automatically get [True, False] example values.
         """
-        for field_name, field in cls.__fields__.items():
+        for _field_name, field in cls.__fields__.items():
+            field_name = alias if (alias := field.alias) else _field_name
+
             field_type = field.annotation
             datapath = parent_datapath + f".{field_name}"
 
@@ -225,8 +231,7 @@ class ActionOutput(BaseModel):
 
 
 class GenericActionOutput(ActionOutput):
-    """
-    Output class for generic actions.
+    """Output class for generic actions.
 
     This class extends the `ActionOutput` class and adds a status_code and response_body field. You can use this class as is or extend it to add more fields.
 

--- a/src/soar_sdk/app.py
+++ b/src/soar_sdk/app.py
@@ -541,7 +541,7 @@ class App:
             return all(statuses)
 
         if isinstance(result, ActionOutput):
-            output_dict = result.dict()
+            output_dict = result.dict(by_alias=True)
             param_dict = action_params.dict() if action_params else None
             result = ActionResult(
                 status=True,

--- a/tests/example_app/app.json
+++ b/tests/example_app/app.json
@@ -128,6 +128,10 @@
                 {
                     "data_path": "action_result.data.*.reversed_string",
                     "data_type": "string"
+                },
+                {
+                    "data_path": "action_result.data.*._underscored_string",
+                    "data_type": "string"
                 }
             ],
             "render": {

--- a/tests/example_app/src/actions/reverse_string.py
+++ b/tests/example_app/src/actions/reverse_string.py
@@ -1,6 +1,6 @@
 from soar_sdk.logging import getLogger
 from soar_sdk.abstract import SOARClient
-from soar_sdk.action_results import ActionOutput
+from soar_sdk.action_results import ActionOutput, OutputField
 from soar_sdk.params import Params
 
 logger = getLogger()
@@ -16,6 +16,7 @@ class ReverseStringOutput(ActionOutput):
 
     original_string: str
     reversed_string: str
+    underscored_string: str = OutputField(alias="_underscored_string")
 
 
 def reverse_string(param: ReverseStringParams, soar: SOARClient) -> ReverseStringOutput:
@@ -23,7 +24,9 @@ def reverse_string(param: ReverseStringParams, soar: SOARClient) -> ReverseStrin
     reversed_string = param.input_string[::-1]
     logger.debug("reversed_string %s", reversed_string)
     return ReverseStringOutput(
-        original_string=param.input_string, reversed_string=reversed_string
+        original_string=param.input_string,
+        reversed_string=reversed_string,
+        underscored_string=f"{param.input_string}_{reversed_string}",
     )
 
 


### PR DESCRIPTION
## Features
List any new features you've added to the SDK:
 -

## Bug Fixes
Describe any bugs you've fixed. Link to the relevant GitHub Issues, if any:
 - Pydantic ignores any model field name that starts with an underscore, so certain output datapaths were unrepresentable. To fix, we are now using the field alias for this when provided.

## Pull Request Checklist
 - [x] I have added or updated unit tests where appropriate.
 - [x] I have updated documentation and example apps where appropriate.
 - [x] My commit messages adhere to the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard.
 - [x] All GitHub Actions and Pre-Commit checks have completed successfully.

## Legal Notice

By submitting a Contribution to this Work, You agree that Your Contribution is made subject to the primary license in the Apache 2.0 license (https://www.apache.org/licenses/LICENSE-2.0.txt). In addition, You represent that: (i) You are the copyright owner of the Contribution or (ii) You have the requisite rights to make the Contribution.

### Definitions:

"You" shall mean: (i) yourself if you are making a Contribution on your own behalf; or (ii) your company, if you are making a Contribution on behalf of your company. If you are making a Contribution on behalf of your company, you represent that you have the requisite authority to do so.

"Contribution" shall mean any original work of authorship, including any modifications or additions to an existing work, that is intentionally submitted by You for inclusion in, or documentation of, this project/repository. For the purposes of this definition, "submitted" means any form of electronic, verbal, or written communication submitted for inclusion in this project/repository, including but not limited to communication on electronic mailing lists, source code control systems, and issue tracking systems that are managed by, or on behalf of, the maintainers of the project/repository.

"Work" shall mean the collective software, content, and documentation in this project/repository.
