### PR TITLE
fix(cli): Add missing `ActionResult.get_message()` function, fix #116

### DIFF
--- a/src/soar_sdk/actions_manager.py
+++ b/src/soar_sdk/actions_manager.py
@@ -84,11 +84,9 @@ class ActionsManager(BaseConnector):
         if handler := self.get_action(action_id):
             try:
                 params = handler.meta.parameters.parse_obj(param)
-            except (ValueError, ValidationError):
-                # FIXME: Consider adding more details to this error, but be aware
-                #  of possible PIIs.
+            except (ValueError, ValidationError) as e:
                 self.save_progress(
-                    "Validation Error - the params data for action could not be parsed"
+                    f"Validation Error - the params data for action could not be parsed: {e!s}"
                 )
                 return
             handler(params)

--- a/src/soar_sdk/app_cli_runner.py
+++ b/src/soar_sdk/app_cli_runner.py
@@ -265,12 +265,7 @@ class AppCliRunner:
 
         if input_data := getattr(args, "raw_input_data", None):
             self.app.handle(input_data)
-            # FIXME: ActionResult mock isn't quite right. Choosing not to unit test this section
-            # yet, because the test will need to be rewritten. We shouldn't be posting our results
-            # into ActionResult.param...
-            for (
-                result
-            ) in self.app.actions_manager.get_action_results():  # pragma: no cover
+            for result in self.app.actions_manager.get_action_results():
                 params_pretty = json.dumps(result.param, indent=2, ensure_ascii=False)
                 data_pretty = json.dumps(
                     result.get_data(), indent=2, ensure_ascii=False

--- a/src/soar_sdk/app_cli_runner.py
+++ b/src/soar_sdk/app_cli_runner.py
@@ -257,9 +257,9 @@ class AppCliRunner:
         )
         print(f"Parsed webhook request: {args.webhook_request}")
 
-    def run(self) -> None:
+    def run(self, argv: Optional[list[str]] = None) -> None:
         """Run the app CLI."""
-        args = self.parse_args()
+        args = self.parse_args(argv=argv)
 
         logger = PhantomLogger()
 

--- a/src/soar_sdk/params.py
+++ b/src/soar_sdk/params.py
@@ -28,8 +28,6 @@ def Param(
     Use this function to define the default value for an action parameter that requires
     extra metadata for the manifest. This function is a thin wrapper around pydantic.Field.
 
-    :param order: The order key, starting at 0, allows the app
-      author to control the display order of the controls in the UI.
     :param description: A short description of this parameter.
       The description is shown in the user interface when running an action manually.
     :param default: To set the default value of a variable in the UI, use this key.

--- a/src/soar_sdk/shims/phantom/action_result.py
+++ b/src/soar_sdk/shims/phantom/action_result.py
@@ -52,5 +52,8 @@ if TYPE_CHECKING or not _soar_is_available:
         def get_summary(self) -> dict:
             return self.summary
 
+        def get_message(self) -> str:
+            return self.message
+
 
 __all__ = ["ActionResult"]

--- a/tests/cli/manifests/test_processors.py
+++ b/tests/cli/manifests/test_processors.py
@@ -4,19 +4,20 @@ from unittest import mock
 import json
 from datetime import datetime
 
+import pytest_mock
+
 from soar_sdk.cli.manifests.processors import ManifestProcessor
 from soar_sdk.compat import UPDATE_TIME_FORMAT
 
 
-def test_manifest_processor_creating_json_from_meta():
+def test_manifest_processor_creating_json_from_meta(mocker: pytest_mock.MockerFixture):
     processor = ManifestProcessor(
         "example_app.json", project_context="./tests/example_app"
     )
-    processor.save_json_manifest = mock.Mock()
 
+    save_json_manifest = mocker.patch.object(processor, "save_json_manifest")
     processor.create()
-
-    processor.save_json_manifest.assert_called_once()
+    save_json_manifest.assert_called_once()
 
 
 @mock.patch("builtins.open", new_callable=mock.mock_open, read_data="data")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,3 @@
-import json
 from unittest import mock
 
 import pytest
@@ -45,12 +44,6 @@ def example_app() -> App:
         product_name="Example App",
         publisher="Splunk",
     )
-    app.actions_manager._load_app_json = mock.Mock(return_value=True)
-    app.actions_manager.get_state_dir = mock.Mock(return_value="/tmp/")
-    app.actions_manager._load_app_json = mock.Mock(return_value=True)
-
-    with open("tests/example_app/app.json") as app_json:
-        app.actions_manager._BaseConnector__app_json = json.load(app_json)
 
     return app
 

--- a/tests/stubs.py
+++ b/tests/stubs.py
@@ -6,7 +6,7 @@ from soar_sdk.params import Param, Params
 
 
 class SampleActionParams(Params):
-    field1: int = Param(0, "Some description")
+    field1: int = Param(description="Some description", required=False, default=5)
 
 
 class BaseConnectorMock(mock.Mock):

--- a/tests/test_generic_action.py
+++ b/tests/test_generic_action.py
@@ -1,7 +1,7 @@
 import pytest
+import pytest_mock
 from soar_sdk.abstract import SOARClient
 from soar_sdk.action_results import GenericActionOutput, OutputField
-from unittest import mock
 from soar_sdk.app import App
 from soar_sdk.params import GenericActionParams, Params
 from soar_sdk.exceptions import ActionFailure
@@ -30,7 +30,9 @@ def test_generic_action_decoration_fails_when_used_more_than_once(app_with_actio
     )
 
 
-def test_generic_action_decoration(app_with_action: App):
+def test_generic_action_decoration(
+    app_with_action: App, mocker: pytest_mock.MockerFixture
+):
     @app_with_action.generic_action()
     def http_action(params: GenericActionParams) -> GenericActionOutput:
         """
@@ -41,10 +43,12 @@ def test_generic_action_decoration(app_with_action: App):
             response_body="Hello, world!",
         )
 
-    app_with_action.actions_manager = mock.Mock()
+    manager_mock = mocker.patch.object(
+        app_with_action, "actions_manager", autospec=True
+    )
     result = http_action(params=GenericActionParams(http_method="GET", endpoint="/"))
     assert result
-    assert app_with_action.actions_manager.add_result.call_count == 1
+    assert manager_mock.add_result.call_count == 1
 
 
 def test_generic_action_without_generic_action_params(app_with_action: App):
@@ -84,7 +88,9 @@ def test_invalid_output_type(app_with_action: App):
     )
 
 
-def test_generic_action_output_class(app_with_action: App):
+def test_generic_action_output_class(
+    app_with_action: App, mocker: pytest_mock.MockerFixture
+):
     class CustomGenericActionOutput(GenericActionOutput):
         error: str = OutputField(example_values=["Invalid credentials"])
 
@@ -96,13 +102,15 @@ def test_generic_action_output_class(app_with_action: App):
             error="Invalid credentials",
         )
 
-    app_with_action.actions_manager = mock.Mock()
+    manager_mock = mocker.patch.object(
+        app_with_action, "actions_manager", autospec=True
+    )
     result = http_action(
         params=GenericActionParams(http_method="GET", endpoint="/"),
         asset=ValidAsset(normal_field="test", another_field=42),
     )
     assert result
-    assert app_with_action.actions_manager.add_result.call_count == 1
+    assert manager_mock.add_result.call_count == 1
 
 
 def test_no_output_class(app_with_action: App):
@@ -118,36 +126,36 @@ def test_no_output_class(app_with_action: App):
     )
 
 
-def test_parameter_validation_error(app_with_action: App):
+def test_parameter_validation_error(
+    app_with_action: App, mocker: pytest_mock.MockerFixture
+):
     """Test that parameter validation errors are handled properly (lines 93-95)"""
 
     @app_with_action.generic_action()
     def http_action(params: GenericActionParams) -> GenericActionOutput:
         return GenericActionOutput(status_code=200, response_body="OK")
 
-    app_with_action.actions_manager = mock.Mock()
+    manager_mock = mocker.patch.object(
+        app_with_action, "actions_manager", autospec=True
+    )
 
     invalid_params = "invalid"
 
     result = http_action(params=invalid_params)
 
     assert result is False
-    assert app_with_action.actions_manager.add_result.call_count == 1
+    assert manager_mock.add_result.call_count == 1
 
 
 def test_generic_action_raises_exception_propagates(app_with_action: App):
     """Test that exceptions raised in the generic action function are handled and return False."""
 
     @app_with_action.generic_action()
-    def http_action(params: GenericActionParams, client=None) -> GenericActionOutput:
+    def http_action(params: GenericActionParams) -> GenericActionOutput:
         raise ValueError("error")
         return GenericActionOutput(status_code=200, response_body="OK")
 
-    client_mock = mock.Mock()
-
-    result = http_action(
-        params=GenericActionParams(http_method="GET", endpoint="/"), client=client_mock
-    )
+    result = http_action(params=GenericActionParams(http_method="GET", endpoint="/"))
     assert result is False
 
 

--- a/tests/test_on_poll.py
+++ b/tests/test_on_poll.py
@@ -1,6 +1,7 @@
 from collections.abc import Iterator
 import pytest
-from unittest import mock
+
+import pytest_mock
 
 from soar_sdk.app import App
 from soar_sdk.params import OnPollParams
@@ -36,16 +37,17 @@ def test_on_poll_decoration_fails_when_not_generator(app_with_action: App):
             return {"data": "test"}  # Not yielding
 
 
-def test_on_poll_function_called_with_params(app_with_action: App):
+def test_on_poll_function_called_with_params(
+    app_with_action: App, mocker: pytest_mock.MockerFixture
+):
     """Test that the on_poll function is called with parameters."""
-    poll_fn = mock.Mock(return_value=iter([{"data": "test"}]))
+    poll_fn = mocker.stub()
 
     @app_with_action.on_poll()
-    def on_poll_function(params: OnPollParams, client=None) -> Iterator[dict]:
+    def on_poll_function(params: OnPollParams) -> Iterator[dict]:
         poll_fn(params)
         yield {"data": "test"}
 
-    client_mock = mock.Mock()
     params = OnPollParams(
         start_time=0,
         end_time=1,
@@ -54,7 +56,7 @@ def test_on_poll_function_called_with_params(app_with_action: App):
         container_id=1,
     )
 
-    result = on_poll_function(params, client=client_mock)
+    result = on_poll_function(params)
 
     poll_fn.assert_called_once_with(params)
     assert result is True
@@ -62,14 +64,13 @@ def test_on_poll_function_called_with_params(app_with_action: App):
 
 def test_on_poll_param_validation_error(app_with_action: App):
     """Test on_poll handles parameter validation errors and returns False."""
-    client_mock = mock.Mock()
 
     @app_with_action.on_poll()
     def on_poll_function(params: OnPollParams):
         yield Artifact(name="a1")
 
     invalid_params = "invalid"
-    result = on_poll_function(invalid_params, client=client_mock)
+    result = on_poll_function(invalid_params)
     assert result is False
 
 
@@ -77,11 +78,10 @@ def test_on_poll_works_with_iterator_functions(app_with_action: App):
     """Test that the on_poll decorator works with functions that return iterators."""
 
     @app_with_action.on_poll()
-    def on_poll_function(params: OnPollParams, client=None) -> Iterator[dict]:
+    def on_poll_function(params: OnPollParams) -> Iterator[dict]:
         # Creating and returning an iterator
         return iter([{"data": "test artifact 1"}, {"data": "test artifact 2"}])
 
-    client_mock = mock.Mock()
     params = OnPollParams(
         start_time=0,
         end_time=1,
@@ -89,7 +89,7 @@ def test_on_poll_works_with_iterator_functions(app_with_action: App):
         artifact_count=100,
     )
 
-    result = on_poll_function(params, client=client_mock)
+    result = on_poll_function(params)
 
     assert result is True
 
@@ -98,18 +98,17 @@ def test_on_poll_empty_iterator(app_with_action: App):
     """Test that the on_poll function works with empty iterators."""
 
     @app_with_action.on_poll()
-    def on_poll_function(params: OnPollParams, client=None) -> Iterator[dict]:
+    def on_poll_function(params: OnPollParams) -> Iterator[dict]:
         # Empty iterator - no artifacts to yield
         return iter([])
 
-    client_mock = mock.Mock()
     params = OnPollParams(
         start_time=0,
         end_time=1,
         container_id=1,
     )
 
-    result = on_poll_function(params, client=client_mock)
+    result = on_poll_function(params)
 
     assert result is True
 
@@ -118,11 +117,10 @@ def test_on_poll_raises_exception_propagates(app_with_action: App):
     """Test that exceptions raised in the on_poll function are handled and return False."""
 
     @app_with_action.on_poll()
-    def on_poll_function(params: OnPollParams, client=None) -> Iterator[dict]:
+    def on_poll_function(params: OnPollParams) -> Iterator[dict]:
         raise ValueError("poll error")
         yield  # pragma: no cover
 
-    client_mock = mock.Mock()
     params = OnPollParams(
         start_time=0,
         end_time=1,
@@ -131,7 +129,7 @@ def test_on_poll_raises_exception_propagates(app_with_action: App):
         container_id=1,
     )
 
-    result = on_poll_function(params, client=client_mock)
+    result = on_poll_function(params)
     assert result is False
 
 
@@ -140,12 +138,11 @@ def test_on_poll_multiple_yields(app_with_action: App):
     yielded = []
 
     @app_with_action.on_poll()
-    def on_poll_function(params: OnPollParams, client=None) -> Iterator[dict]:
+    def on_poll_function(params: OnPollParams) -> Iterator[dict]:
         for i in range(3):
             yielded.append(i)
             yield {"data": i}
 
-    client_mock = mock.Mock()
     params = OnPollParams(
         start_time=0,
         end_time=1,
@@ -154,21 +151,27 @@ def test_on_poll_multiple_yields(app_with_action: App):
         container_id=1,
     )
 
-    result = on_poll_function(params, client=client_mock)
+    result = on_poll_function(params)
     assert result is True
     assert yielded == [0, 1, 2]
 
 
-def test_on_poll_yields_container_success(app_with_action: App):
+def test_on_poll_yields_container_success(
+    app_with_action: App, mocker: pytest_mock.MockerFixture
+):
     """Test on_poll yields a Container and successfully."""
 
     # Mock the save_container method to return success
-    app_with_action.actions_manager.save_container = mock.Mock()
-    app_with_action.actions_manager.save_container.return_value = (True, "Created", 42)
+    save_container = mocker.patch.object(
+        app_with_action.actions_manager,
+        "save_container",
+        return_value=(True, "Created", 42),
+    )
 
     # Mock the save_artifacts method
-    app_with_action.actions_manager.save_artifacts = mock.Mock()
-    app_with_action.actions_manager.save_artifacts.return_value = None
+    save_artifacts = mocker.patch.object(
+        app_with_action.actions_manager, "save_artifacts", return_value=None
+    )
 
     @app_with_action.on_poll()
     def on_poll_function(params: OnPollParams, client=None):
@@ -178,20 +181,22 @@ def test_on_poll_yields_container_success(app_with_action: App):
     params = OnPollParams(start_time=0, end_time=1)
     result = on_poll_function(params, client=app_with_action.soar_client)
     assert result is True
-    assert app_with_action.actions_manager.save_container.call_count == 1
-    app_with_action.actions_manager.save_artifacts.assert_called()
+    assert save_container.call_count == 1
+    save_artifacts.assert_called()
 
 
-def test_on_poll_yields_container_duplicate(app_with_action: App):
+def test_on_poll_yields_container_duplicate(
+    app_with_action: App, mocker: pytest_mock.MockerFixture
+):
     """Test on_poll yields a Container and handles duplicate container correctly."""
-    app_with_action.actions_manager.save_container = mock.Mock()
-    app_with_action.actions_manager.save_artifacts = mock.Mock()
-    app_with_action.actions_manager.save_container.return_value = (
-        True,
-        "Duplicate container found",
-        99,
+    save_container = mocker.patch.object(
+        app_with_action.actions_manager,
+        "save_container",
+        return_value=(True, "Duplicate container found", 99),
     )
-    app_with_action.actions_manager.save_artifacts.return_value = None
+    save_artifacts = mocker.patch.object(
+        app_with_action.actions_manager, "save_artifacts", return_value=None
+    )
 
     @app_with_action.on_poll()
     def on_poll_function_dup(params: OnPollParams, client=None):
@@ -201,20 +206,26 @@ def test_on_poll_yields_container_duplicate(app_with_action: App):
     params = OnPollParams(start_time=0, end_time=1)
     result = on_poll_function_dup(params, client=app_with_action.soar_client)
     assert result is True
-    assert app_with_action.actions_manager.save_container.call_count == 1
-    app_with_action.actions_manager.save_artifacts.assert_called()
+    assert save_container.call_count == 1
+    save_artifacts.assert_called()
 
 
-def test_on_poll_yields_container_creation_failure(app_with_action: App):
+def test_on_poll_yields_container_creation_failure(
+    app_with_action: App, mocker: pytest_mock.MockerFixture
+):
     """Test on_poll handles container creation failure correctly."""
-    app_with_action.actions_manager.save_container = mock.Mock()
-    app_with_action.actions_manager.save_artifacts = mock.Mock()
-    app_with_action.actions_manager.save_container.return_value = (
-        False,
-        "Error creating container",
-        None,
+    save_container = mocker.patch.object(
+        app_with_action.actions_manager,
+        "save_container",
+        return_value=(
+            False,
+            "Error creating container",
+            None,
+        ),
     )
-    app_with_action.actions_manager.save_artifacts.return_value = None
+    save_artifacts = mocker.patch.object(
+        app_with_action.actions_manager, "save_artifacts", return_value=None
+    )
 
     @app_with_action.on_poll()
     def on_poll_function(params: OnPollParams, client=None):
@@ -224,40 +235,42 @@ def test_on_poll_yields_container_creation_failure(app_with_action: App):
     params = OnPollParams(start_time=0, end_time=1)
     result = on_poll_function(params, client=app_with_action.soar_client)
     assert result is True
-    assert app_with_action.actions_manager.save_container.call_count == 1
-    app_with_action.actions_manager.save_artifacts.assert_not_called()
+    assert save_container.call_count == 1
+    save_artifacts.assert_not_called()
 
 
 def test_on_poll_yields_non_container_artifact(app_with_action: App):
     """Test on_poll correctly handles object that is neither Container nor Artifact."""
-    client_mock = mock.Mock()
 
     @app_with_action.on_poll()
-    def on_poll_function(params: OnPollParams, client=None):
+    def on_poll_function(params: OnPollParams):
         yield 123  # Should be skipped
         yield "string"
 
     params = OnPollParams(start_time=0, end_time=1)
-    result = on_poll_function(params, client=client_mock)
+    result = on_poll_function(params)
     assert result is True
 
 
 def test_on_poll_artifact_no_container(app_with_action: App):
     """Test on_poll yields an Artifact with no container and no container_id."""
-    client_mock = mock.Mock()
 
     @app_with_action.on_poll()
-    def on_poll_function(params: OnPollParams, client=None):
+    def on_poll_function(params: OnPollParams):
         yield Artifact(name="a1")
 
     params = OnPollParams(start_time=0, end_time=1)
-    result = on_poll_function(params, client=client_mock)
+    result = on_poll_function(params)
     assert result is True
 
 
-def test_on_poll_sets_container_id_on_artifact(app_with_action: App):
+def test_on_poll_sets_container_id_on_artifact(
+    app_with_action: App, mocker: pytest_mock.MockerFixture
+):
     """Test that on_poll sets container_id on artifact if not present and container_id is available."""
-    app_with_action.actions_manager.save_artifacts = mock.Mock()
+    save_artifacts = mocker.patch.object(
+        app_with_action.actions_manager, "save_artifacts"
+    )
 
     @app_with_action.on_poll()
     def on_poll_function(params: OnPollParams, client=None):
@@ -266,23 +279,22 @@ def test_on_poll_sets_container_id_on_artifact(app_with_action: App):
 
     params = OnPollParams(start_time=0, end_time=1)
     on_poll_function(params, client=app_with_action.soar_client)
-    called_artifacts = app_with_action.actions_manager.save_artifacts.call_args_list
+    called_artifacts = save_artifacts.call_args_list
     saved_artifact = called_artifacts[0][0][0][0]
     assert saved_artifact["container_id"] == 999
 
 
 def test_on_poll_failure(app_with_action: App):
     """Test on_poll handles ActionFailure correctly."""
-    client_mock = mock.Mock()
 
     # ActionFailure
     @app_with_action.on_poll()
-    def on_poll_actionfailure(params: OnPollParams, client=None):
+    def on_poll_actionfailure(params: OnPollParams):
         raise ActionFailure("failmsg")
         yield  # pragma: no cover
 
     params = OnPollParams(start_time=0, end_time=1)
-    result = on_poll_actionfailure(params, client=client_mock)
+    result = on_poll_actionfailure(params)
     assert result is False
 
 
@@ -290,7 +302,7 @@ def test_on_poll_decoration_with_meta(app_with_action: App):
     """Test that the on_poll decorator properly sets up metadata."""
 
     @app_with_action.on_poll()
-    def on_poll_function(params: OnPollParams, client=None) -> Iterator[dict]:
+    def on_poll_function(params: OnPollParams) -> Iterator[dict]:
         yield {"data": "test"}
 
     action = app_with_action.actions_manager.get_action("on_poll")
@@ -303,7 +315,7 @@ def test_on_poll_actionmeta_dict_output_empty(app_with_action: App):
     """Test that OnPollActionMeta.dict returns output as an empty list."""
 
     @app_with_action.on_poll()
-    def on_poll_function(params: OnPollParams, client=None):
+    def on_poll_function(params: OnPollParams):
         yield Artifact(name="a1")
 
     action = app_with_action.actions_manager.get_action("on_poll")


### PR DESCRIPTION
## Features
List any new features you've added to the SDK:
 -

## Bug Fixes
Describe any bugs you've fixed. Link to the relevant GitHub Issues, if any:
 - refactor(tests): using the safer pytest-mock instead of raw mocks
- fix(cli): add missing ActionResult.get_message() shim, resolving CLI bug. Fixes #116 
- fix(docs): remove reference to defunct 'order' arg of 'Param'


## Pull Request Checklist
 - [x] I have added or updated unit tests where appropriate.
 - [x] I have updated documentation and example apps where appropriate.
 - [x] My commit messages adhere to the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard.
 - [x] All GitHub Actions and Pre-Commit checks have completed successfully.

## Legal Notice

By submitting a Contribution to this Work, You agree that Your Contribution is made subject to the primary license in the Apache 2.0 license (https://www.apache.org/licenses/LICENSE-2.0.txt). In addition, You represent that: (i) You are the copyright owner of the Contribution or (ii) You have the requisite rights to make the Contribution.

### Definitions:

"You" shall mean: (i) yourself if you are making a Contribution on your own behalf; or (ii) your company, if you are making a Contribution on behalf of your company. If you are making a Contribution on behalf of your company, you represent that you have the requisite authority to do so.

"Contribution" shall mean any original work of authorship, including any modifications or additions to an existing work, that is intentionally submitted by You for inclusion in, or documentation of, this project/repository. For the purposes of this definition, "submitted" means any form of electronic, verbal, or written communication submitted for inclusion in this project/repository, including but not limited to communication on electronic mailing lists, source code control systems, and issue tracking systems that are managed by, or on behalf of, the maintainers of the project/repository.

"Work" shall mean the collective software, content, and documentation in this project/repository.
