### PR TITLE
fix: pass empty messages to platform instead of setting dummy message

### DIFF
--- a/src/soar_sdk/abstract.py
+++ b/src/soar_sdk/abstract.py
@@ -234,6 +234,6 @@ class SOARClient(Generic[SummaryType]):
         pass
 
     @abstractmethod
-    def get_message(self) -> Optional[str]:
+    def get_message(self) -> str:
         """Get the summary message for the action run."""
         pass

--- a/src/soar_sdk/app.py
+++ b/src/soar_sdk/app.py
@@ -632,7 +632,7 @@ class App:
         ],
         actions_manager: ActionsManager,
         action_params: Optional[Params] = None,
-        message: Optional[str] = None,
+        message: str = "",
         summary: Optional[ActionOutput] = None,
     ) -> bool:
         """Handles multiple ways of returning response from action.
@@ -653,18 +653,13 @@ class App:
                 )
             # Handle empty list/iterator case
             if not statuses:
-                result = ActionOutput(
-                    status=True, message=message or "Action completed successfully"
-                )
+                result = ActionOutput(status=True, message=message)
             else:
                 return all(statuses)
 
         if isinstance(result, ActionOutput):
             output_dict = result.dict(by_alias=True)
             param_dict = action_params.dict() if action_params else None
-
-            if not message:
-                message = "Action completed successfully"
 
             result = ActionResult(
                 status=True,

--- a/src/soar_sdk/app_client.py
+++ b/src/soar_sdk/app_client.py
@@ -44,7 +44,7 @@ class AppClient(SOARClient[SummaryType]):
         self.basic_auth: Optional[BasicAuth] = None
 
         self._summary: Optional[SummaryType] = None
-        self._message: Optional[str] = None
+        self._message: str = ""
         self.__container_id: int = 0
         self.__asset_id: str = ""
 
@@ -171,6 +171,6 @@ class AppClient(SOARClient[SummaryType]):
         """Get the summary for the action result."""
         return self._summary
 
-    def get_message(self) -> Optional[str]:
+    def get_message(self) -> str:
         """Get the message for the action result."""
         return self._message

--- a/tests/test_actions_manager.py
+++ b/tests/test_actions_manager.py
@@ -98,10 +98,7 @@ def test_action_called_returning_iterator(
     example_app.handle(simple_action_input.json())
 
     assert len(example_app.actions_manager.get_results()) == 5
-    assert all(
-        "success" in result.message
-        for result in example_app.actions_manager.get_results()
-    )
+    assert all(result.status for result in example_app.actions_manager.get_results())
 
 
 def test_async_action_called_returning_iterator(
@@ -120,10 +117,7 @@ def test_async_action_called_returning_iterator(
     example_app.handle(simple_action_input.json())
 
     assert len(example_app.actions_manager.get_results()) == 5
-    assert all(
-        "success" in result.message
-        for result in example_app.actions_manager.get_results()
-    )
+    assert all(result.status for result in example_app.actions_manager.get_results())
 
 
 def test_action_called_returning_list(
@@ -139,10 +133,7 @@ def test_action_called_returning_list(
     example_app.handle(simple_action_input.json())
 
     assert len(example_app.actions_manager.get_results()) == 5
-    assert all(
-        "success" in result.message
-        for result in example_app.actions_manager.get_results()
-    )
+    assert all(result.status for result in example_app.actions_manager.get_results())
 
 
 def test_async_action_called_returning_list(
@@ -158,10 +149,7 @@ def test_async_action_called_returning_list(
     example_app.handle(simple_action_input.json())
 
     assert len(example_app.actions_manager.get_results()) == 5
-    assert all(
-        "success" in result.message
-        for result in example_app.actions_manager.get_results()
-    )
+    assert all(result.status for result in example_app.actions_manager.get_results())
 
 
 def test_action_called_with_default_message_set(
@@ -174,7 +162,7 @@ def test_action_called_with_default_message_set(
     example_app.handle(simple_action_input.json())
 
     assert len(example_app.actions_manager.get_results()) == 1
-    assert "success" in example_app.actions_manager.get_results()[0].message
+    assert example_app.actions_manager.get_results()[0].status
 
 
 def test_action_called_with_timezone_asset(example_app: App):
@@ -204,7 +192,7 @@ def test_action_called_with_timezone_asset(example_app: App):
     example_app.handle(action_input.json())
 
     assert len(example_app.actions_manager.get_results()) == 1
-    assert "success" in example_app.actions_manager.get_results()[0].message
+    assert example_app.actions_manager.get_results()[0].status
 
 
 def test_actions_provider_running_undefined_action(


### PR DESCRIPTION
## Features
List any new features you've added to the SDK:
 -

## Bug Fixes
Describe any bugs you've fixed. Link to the relevant GitHub Issues, if any:
 - Some apps rely on the summary as their message since the platform will use the summary if no message is provided.
 - We shouldn't have the sdk set some default message if no message is provided

## Pull Request Checklist
 - [ ] I have added or updated unit tests where appropriate.
 - [ ] I have updated documentation and example apps where appropriate.
 - [ ] My commit messages adhere to the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard.
 - [ ] All GitHub Actions and Pre-Commit checks have completed successfully.

## Legal Notice

By submitting a Contribution to this Work, You agree that Your Contribution is made subject to the primary license in the Apache 2.0 license (https://www.apache.org/licenses/LICENSE-2.0.txt). In addition, You represent that: (i) You are the copyright owner of the Contribution or (ii) You have the requisite rights to make the Contribution.

### Definitions:

"You" shall mean: (i) yourself if you are making a Contribution on your own behalf; or (ii) your company, if you are making a Contribution on behalf of your company. If you are making a Contribution on behalf of your company, you represent that you have the requisite authority to do so.

"Contribution" shall mean any original work of authorship, including any modifications or additions to an existing work, that is intentionally submitted by You for inclusion in, or documentation of, this project/repository. For the purposes of this definition, "submitted" means any form of electronic, verbal, or written communication submitted for inclusion in this project/repository, including but not limited to communication on electronic mailing lists, source code control systems, and issue tracking systems that are managed by, or on behalf of, the maintainers of the project/repository.

"Work" shall mean the collective software, content, and documentation in this project/repository.
