### PR TITLE
ci: integration test summary

### DIFF
--- a/.github/scripts/generate_test_summary.py
+++ b/.github/scripts/generate_test_summary.py
@@ -30,10 +30,11 @@ def parse_junit_xml(xml_path: Path) -> TestResult:
     failed = 0
     skipped = 0
     errors = 0
-    duration = float(root.get("time", 0))
+    duration = 0.0
     failures = []
 
     for testsuite in root.findall(".//testsuite"):
+        duration += float(testsuite.get("time", 0))
         passed += (
             int(testsuite.get("tests", 0))
             - int(testsuite.get("failures", 0))
@@ -95,8 +96,8 @@ def generate_markdown_summary(
     total_errors = sum(r.errors for r in results)
     total_tests = total_passed + total_failed + total_skipped + total_errors
 
-    md = "```\nIntegration Test Results\n"
-    md += "━" * 63 + "\n"
+    md = "Integration Test Results\n"
+    md += "━" * 63 + "\n\n"
 
     status = "PASSED" if total_failed + total_errors == 0 else "FAILED"
     md += f"{total_tests} tests: {total_passed} passed, {total_failed + total_errors} failed, {total_skipped} skipped\n"
@@ -110,7 +111,7 @@ def generate_markdown_summary(
     has_failures = any(r.failures for r in results)
     if has_failures:
         md += "\nFailed Tests\n"
-        md += "━" * 63 + "\n"
+        md += "━" * 63 + "\n\n"
         for result in results:
             if result.failures:
                 for failure in result.failures:
@@ -119,12 +120,10 @@ def generate_markdown_summary(
                     message = failure["message"][:200].strip()
                     if len(failure["message"]) > 200:
                         message += "..."
-                    md += f"  {failure['type']}: {message}\n"
-
-    md += "```\n"
+                    md += f"  {failure['type']}: {message}\n\n"
 
     if has_failures and run_url:
-        md += "\n[View full logs and artifacts](" + run_url + ")\n"
+        md += "[View full logs and artifacts](" + run_url + ")\n"
 
     return md
 

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -58,6 +58,7 @@ jobs:
       PHANTOM_USERNAME: ${{ vars.PHANTOM_USERNAME }}
       PHANTOM_PASSWORD: ${{ secrets.PHANTOM_PASSWORD }}
       NUM_TEST_RETRIES: ${{ vars.NUM_TEST_RETRIES || '2' }}
+      PHANTOM_VERSION: ${{ matrix.version }}
       UV_LOCKED: 1
     steps:
       - name: Checkout SDK repository


### PR DESCRIPTION
Test summary step added for aggregating test instance results into one spot

Tests success example:

<img width="493" height="249" alt="Screenshot 2025-11-17 at 2 56 34 PM" src="https://github.com/user-attachments/assets/a74f92a0-bf26-47ee-af04-e1a84910d1ea" />



Test failing on instance example:

<img width="589" height="421" alt="Screenshot 2025-11-17 at 2 50 07 PM" src="https://github.com/user-attachments/assets/ed16d955-b73c-4e7b-af42-c5a3dd855009" />
