### PR TITLE
feat: add a category to asset fields

### DIFF
--- a/tests/cli/test_convert_cli.py
+++ b/tests/cli/test_convert_cli.py
@@ -6,6 +6,7 @@ from unittest.mock import patch
 import pytest
 from typer.testing import CliRunner
 
+from soar_sdk.asset import FieldCategory
 from soar_sdk.cli.init import cli
 from soar_sdk.compat import PythonVersion
 from soar_sdk.meta.actions import ActionMeta
@@ -153,6 +154,7 @@ def test_convert_cli(runner, tmp_path, app_meta):
             description="The username for the application",
             required=True,
             data_type="string",
+            category=FieldCategory.CONNECTIVITY,
         )
     }
 
@@ -195,6 +197,7 @@ def test_convert_cli_updates_py_versions(runner, tmp_path, app_meta):
             description="The username for the application",
             required=True,
             data_type="string",
+            category=FieldCategory.CONNECTIVITY,
         )
     }
 
@@ -239,6 +242,7 @@ def test_convert_cli_with_default_output(runner, tmp_path, app_meta):
             description="The username for the application",
             required=True,
             data_type="string",
+            category=FieldCategory.CONNECTIVITY,
         )
     }
 

--- a/tests/cli/test_deserializers.py
+++ b/tests/cli/test_deserializers.py
@@ -279,6 +279,7 @@ def test_from_app_json_complex_example(create_app_json):
                 "required": True,
                 "description": "Base Url",
                 "order": 0,
+                "category": "connectivity",
             },
             "port": {
                 "data_type": "numeric",
@@ -286,6 +287,7 @@ def test_from_app_json_complex_example(create_app_json):
                 "description": "Port Number",
                 "default": 8080,
                 "order": 1,
+                "category": "connectivity",
             },
             "verify": {
                 "data_type": "boolean",
@@ -293,6 +295,7 @@ def test_from_app_json_complex_example(create_app_json):
                 "description": "Verify",
                 "default": True,
                 "order": 2,
+                "category": "connectivity",
             },
         },
         "actions": [
@@ -370,6 +373,7 @@ def test_from_app_json_preserves_original_data(basic_app_data, create_app_json):
                     "data_type": "string",
                     "required": True,
                     "order": 0,
+                    "category": "connectivity",
                 }
             },
         }

--- a/tests/example_app/app.json
+++ b/tests/example_app/app.json
@@ -24,13 +24,15 @@
             "required": true,
             "description": "Base Url",
             "order": 0,
-            "default": "https://example"
+            "default": "https://example",
+            "category": "connectivity"
         },
         "api_key": {
             "data_type": "password",
             "required": true,
             "description": "API key for authentication",
-            "order": 1
+            "order": 1,
+            "category": "connectivity"
         },
         "key_header": {
             "data_type": "string",
@@ -41,20 +43,23 @@
             "value_list": [
                 "Authorization",
                 "X-API-Key"
-            ]
+            ],
+            "category": "connectivity"
         },
         "timezone": {
             "data_type": "timezone",
             "required": true,
             "description": "Timezone",
-            "order": 3
+            "order": 3,
+            "category": "connectivity"
         },
         "timezone_with_default": {
             "data_type": "timezone",
             "required": true,
             "description": "Timezone With Default",
             "order": 4,
-            "default": "America/Denver"
+            "default": "America/Denver",
+            "category": "action"
         }
     },
     "actions": [

--- a/tests/example_app/src/app.py
+++ b/tests/example_app/src/app.py
@@ -5,7 +5,7 @@ from zoneinfo import ZoneInfo
 from soar_sdk.abstract import SOARClient
 from soar_sdk.action_results import ActionOutput, MakeRequestOutput, OutputField
 from soar_sdk.app import App
-from soar_sdk.asset import AssetField, BaseAsset
+from soar_sdk.asset import AssetField, BaseAsset, FieldCategory
 from soar_sdk.logging import getLogger
 from soar_sdk.models.artifact import Artifact
 from soar_sdk.models.container import Container
@@ -46,7 +46,9 @@ class Asset(BaseAsset):
         description="Header for API key authentication",
     )
     timezone: ZoneInfo
-    timezone_with_default: ZoneInfo = AssetField(default=ZoneInfo("America/Denver"))
+    timezone_with_default: ZoneInfo = AssetField(
+        default=ZoneInfo("America/Denver"), category=FieldCategory.ACTION
+    )
 
 
 app = App(

--- a/tests/example_app_with_webhook/app.json
+++ b/tests/example_app_with_webhook/app.json
@@ -23,13 +23,15 @@
             "data_type": "string",
             "required": true,
             "description": "Base Url",
-            "order": 0
+            "order": 0,
+            "category": "connectivity"
         },
         "api_key": {
             "data_type": "password",
             "required": true,
             "description": "API key for authentication",
-            "order": 1
+            "order": 1,
+            "category": "connectivity"
         },
         "key_header": {
             "data_type": "string",
@@ -40,7 +42,8 @@
             "value_list": [
                 "Authorization",
                 "X-API-Key"
-            ]
+            ],
+            "category": "connectivity"
         }
     },
     "actions": [

--- a/tests/test_asset.py
+++ b/tests/test_asset.py
@@ -1,7 +1,7 @@
 import pytest
 from pydantic import Field
 
-from soar_sdk.asset import AssetField, AssetFieldSpecification, BaseAsset
+from soar_sdk.asset import AssetField, AssetFieldSpecification, BaseAsset, FieldCategory
 from soar_sdk.exceptions import AppContextRequired
 
 
@@ -13,7 +13,11 @@ def test_asset_with_aliased_field():
 
     result = AliasedAsset.to_json_schema()
     assert result["_aliased_field"] == AssetFieldSpecification(
-        data_type="string", required=True, description="Aliased Field", order=0
+        data_type="string",
+        required=True,
+        description="Aliased Field",
+        order=0,
+        category=FieldCategory.CONNECTIVITY,
     )
 
 


### PR DESCRIPTION
## Features
List any new features you've added to the SDK:
 - Add a new "category" to asset config fields, which can be either "connectivity", "action", or "ingest". If no category is specified, the default is "connectivity".

## Bug Fixes
Describe any bugs you've fixed. Link to the relevant GitHub Issues, if any:
 -

## Pull Request Checklist
 - [x] I have added or updated unit tests where appropriate.
 - [x] I have updated documentation and example apps where appropriate.
 - [x] My commit messages adhere to the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard.
 - [x] All GitHub Actions and Pre-Commit checks have completed successfully.

## Legal Notice

By submitting a Contribution to this Work, You agree that Your Contribution is made subject to the primary license in the Apache 2.0 license (https://www.apache.org/licenses/LICENSE-2.0.txt). In addition, You represent that: (i) You are the copyright owner of the Contribution or (ii) You have the requisite rights to make the Contribution.

### Definitions:

"You" shall mean: (i) yourself if you are making a Contribution on your own behalf; or (ii) your company, if you are making a Contribution on behalf of your company. If you are making a Contribution on behalf of your company, you represent that you have the requisite authority to do so.

"Contribution" shall mean any original work of authorship, including any modifications or additions to an existing work, that is intentionally submitted by You for inclusion in, or documentation of, this project/repository. For the purposes of this definition, "submitted" means any form of electronic, verbal, or written communication submitted for inclusion in this project/repository, including but not limited to communication on electronic mailing lists, source code control systems, and issue tracking systems that are managed by, or on behalf of, the maintainers of the project/repository.

"Work" shall mean the collective software, content, and documentation in this project/repository.
