### PR TITLE
feat: add is_file parameter to AssetField for file uploads

### DIFF
--- a/tests/test_asset.py
+++ b/tests/test_asset.py
@@ -125,3 +125,19 @@ def test_asset_state_unavailable_outside_action():
         _ = BaseAsset().cache_state
     with pytest.raises(AppContextRequired):
         _ = BaseAsset().ingest_state
+
+
+def test_file_field():
+    class FileAsset(BaseAsset):
+        certificate: str = AssetField(is_file=True, description="Upload certificate")
+
+    schema = FileAsset.to_json_schema()
+    assert schema["certificate"]["data_type"] == "file"
+
+
+def test_file_field_must_be_str():
+    class BrokenFileAsset(BaseAsset):
+        certificate: int = AssetField(is_file=True)
+
+    with pytest.raises(TypeError, match="must be type str"):
+        BrokenFileAsset.to_json_schema()


### PR DESCRIPTION
Some apps like [microsoftexchangeonpremews](https://github.com/splunk-soar-connectors/microsoftexchangeonpremews) have an asset field type that takes a file, which we don't support in the SDK till now