### PR TITLE
fix: make OutputField default to None instead of required

### DIFF
--- a/src/soar_sdk/action_results.py
+++ b/src/soar_sdk/action_results.py
@@ -133,7 +133,7 @@ def OutputField(
         json_schema_extra["column_name"] = column_name
 
     return Field(
-        default=...,
+        default=None,
         alias=alias,
         json_schema_extra=json_schema_extra if json_schema_extra else None,
     )


### PR DESCRIPTION
Fixed OutputField() to default to None instead of using Pydantic's required sentinel so optional fields are no longer incorrectly enforced as required when using OutputField

Example:

This can be None but will fail if it is because of OutputField
```
Message_ID: str | None = OutputField(cef_types=["internet message id"])
```

Test error:
```
self.__pydantic_validator__.validate_python(data, self_instance=self)\npydantic_core._pydantic_core.ValidationError: 1 validation error for GetEmailOutput\nMessage_ID\n  Field required [type=missing, input_value={'t_Subject': 'Test-Diff-...\"t:ForwardItem\": null}'}, input_type=dict]\n    For further information visit [https://errors.pydantic.dev/2.12/v/missing\n](https://errors.pydantic.dev/2.12/v/missing/n)",
```