### PR TITLE
feat: allow apps to have "permissive" outputs and skip pydantic validation

### DIFF
--- a/tests/test_permissive_action_results.py
+++ b/tests/test_permissive_action_results.py
@@ -1,0 +1,86 @@
+import pytest
+
+from soar_sdk.action_results import ActionOutput, OutputField, PermissiveActionOutput
+
+
+class ExampleInnerData(ActionOutput):
+    inner_string: str = OutputField(
+        example_values=["example_value_1", "example_value_2"]
+    )
+
+
+class ExampleActionOutput(PermissiveActionOutput):
+    under_field: str = OutputField(alias="_under_field")
+    stringy_field: str
+    list_of_strings: list[str]
+    nested_lists: list[list[int]]
+    cef_data: str = OutputField(
+        cef_types=["ip"], example_values=["192.168.0.1", "1.1.1.1"]
+    )
+    nested_type: ExampleInnerData
+    list_of_types: list[ExampleInnerData]
+    optional_field: str | None = None
+    optional_inner_field: ExampleInnerData | None = None
+    optional_list_of_types: list[ExampleInnerData] | None = None
+
+
+@pytest.fixture
+def valid() -> ExampleActionOutput:
+    return ExampleActionOutput(
+        under_field="test",
+        stringy_field="test2",
+        list_of_strings=["a", "b", "c"],
+        nested_lists=[[0, 1, 2], []],
+        cef_data="192.168.0.1",
+        nested_type=ExampleInnerData(inner_string="test_inner"),
+        list_of_types=[ExampleInnerData(inner_string="test")],
+    )
+
+
+@pytest.fixture
+def invalid() -> ExampleActionOutput:
+    return ExampleActionOutput(
+        **{
+            "_under_field": "test",
+            "list_of_strings": ["a", "b", "c"],
+            "nested_lists": [[0, 1, 2], []],
+            "nested_type": {"inner_string": "test_inner"},
+            "list_of_types": [{"inner_string": "test_inner"}, {}],
+        }
+    )
+
+
+def test_parse(valid: ExampleActionOutput, invalid: ExampleActionOutput):
+    assert valid is not None
+    assert invalid is not None
+
+
+def test_access(invalid: ExampleActionOutput):
+    assert invalid.under_field == "test"
+
+
+def test_nested_access(invalid: ExampleActionOutput):
+    assert invalid.nested_type.inner_string == "test_inner"
+
+
+def test_list_nested_access(invalid: ExampleActionOutput):
+    assert invalid.list_of_types[0].inner_string == "test_inner"
+
+
+def test_missing_attribute_raises(invalid: ExampleActionOutput):
+    with pytest.raises(AttributeError):
+        _ = invalid.missing_field
+
+
+def test_access_unknown_field():
+    test = ExampleActionOutput(
+        **{
+            "_under_field": "test",
+            "bob": True,
+            "list_of_strings": ["a", "b", "c"],
+            "nested_lists": [[0, 1, 2], []],
+            "nested_type": {"inner_string": "test_inner"},
+            "list_of_types": [{"inner_string": "test_inner"}, {}],
+        }
+    )
+    assert test.bob


### PR DESCRIPTION

## Features
List any new features you've added to the SDK:
 - Introduce `PermissiveActionOutput` models, which skip strict Pydantic validation

## Bug Fixes
Describe any bugs you've fixed. Link to the relevant GitHub Issues, if any:
 -

## Pull Request Checklist
 - [X] I have added or updated unit tests where appropriate.
 - [X] I have updated documentation and example apps where appropriate.
 - [X] My commit messages adhere to the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard.
 - [X] All GitHub Actions and Pre-Commit checks have completed successfully.

## Legal Notice

By submitting a Contribution to this Work, You agree that Your Contribution is made subject to the primary license in the Apache 2.0 license (https://www.apache.org/licenses/LICENSE-2.0.txt). In addition, You represent that: (i) You are the copyright owner of the Contribution or (ii) You have the requisite rights to make the Contribution.

### Definitions:

"You" shall mean: (i) yourself if you are making a Contribution on your own behalf; or (ii) your company, if you are making a Contribution on behalf of your company. If you are making a Contribution on behalf of your company, you represent that you have the requisite authority to do so.

"Contribution" shall mean any original work of authorship, including any modifications or additions to an existing work, that is intentionally submitted by You for inclusion in, or documentation of, this project/repository. For the purposes of this definition, "submitted" means any form of electronic, verbal, or written communication submitted for inclusion in this project/repository, including but not limited to communication on electronic mailing lists, source code control systems, and issue tracking systems that are managed by, or on behalf of, the maintainers of the project/repository.

"Work" shall mean the collective software, content, and documentation in this project/repository.
