### PR TITLE
feat: clean up stranded containers on failed es poll batch

### DIFF
--- a/src/soar_sdk/apis/container.py
+++ b/src/soar_sdk/apis/container.py
@@ -151,6 +151,28 @@ class Container:
             self.__containers[next_container_id] = container
             return next_container_id
 
+    def delete(self, container_id: int) -> None:
+        """Delete a container from the SOAR platform.
+
+        Args:
+            container_id: The ID of the container to delete.
+
+        Raises:
+            SoarAPIError: If the API request fails or the container cannot be deleted.
+        """
+        if is_client_authenticated(self.soar_client.client):
+            endpoint = f"rest/container/{container_id}"
+            try:
+                self.soar_client.delete(endpoint)
+            except Exception as e:
+                raise SoarAPIError(
+                    f"Failed to delete container {container_id}: {e}"
+                ) from e
+        else:
+            if container_id not in self.__containers:
+                raise SoarAPIError(f"Container {container_id} not found")
+            del self.__containers[container_id]
+
     def _prepare_container(self, container: dict) -> None:
         """Prepare container data by applying default values and validating required fields.
 

--- a/src/soar_sdk/asset_state.py
+++ b/src/soar_sdk/asset_state.py
@@ -24,9 +24,37 @@ class AssetState(MutableMapping[AssetStateKeyType, AssetStateValueType]):
         self.state_key = state_key
         self.asset_id = asset_id
         self.app_id = app_id
+        self._transaction_buffer: AssetStateType | None = None
+
+    @property
+    def in_transaction(self) -> bool:
+        """Whether a transaction is currently active."""
+        return self._transaction_buffer is not None
+
+    def begin_transaction(self) -> None:
+        """Begin a transaction. Writes are buffered until commit() is called."""
+        if self.in_transaction:
+            raise RuntimeError("Transaction already active")
+        self._transaction_buffer = self.get_all()
+
+    def commit(self) -> None:
+        """Flush buffered writes to the backend."""
+        if self._transaction_buffer is None:
+            raise RuntimeError("No active transaction")
+        buffered = self._transaction_buffer
+        self._transaction_buffer = None
+        self.put_all(buffered)
+
+    def rollback(self) -> None:
+        """Discard buffered writes."""
+        if not self.in_transaction:
+            raise RuntimeError("No active transaction")
+        self._transaction_buffer = None
 
     def get_all(self, *, force_reload: bool = False) -> AssetStateType:
         """Get the entirety of this part of the asset state."""
+        if self._transaction_buffer is not None:
+            return dict(self._transaction_buffer)
         if force_reload:
             # backend is from phantom_common shim, whose imports are replaced with Any
             self.backend.reload_state_from_file(  # ty: ignore[unresolved-attribute]
@@ -40,6 +68,9 @@ class AssetState(MutableMapping[AssetStateKeyType, AssetStateValueType]):
 
     def put_all(self, new_value: AssetStateType) -> None:
         """Entirely replace this part of the asset state."""
+        if self.in_transaction:
+            self._transaction_buffer = dict(new_value)
+            return
         part_json = json.dumps(new_value)
         part_encrypted = encryption_helper.encrypt(part_json, salt=self.asset_id)
         state = self.backend.load_state() or {}

--- a/src/soar_sdk/decorators/on_es_poll.py
+++ b/src/soar_sdk/decorators/on_es_poll.py
@@ -173,6 +173,7 @@ class OnESPollDecorator:
             max_findings = action_params.container_count or None
             batch_size = soar.MAX_BULK_FINDINGS
             generator_exhausted = False
+            ingest_state = self.app.asset._ingest_state
             try:
                 system_info = soar.get("/rest/system_info").json()
                 base_url = system_info.get("base_url", "").rstrip("/")
@@ -205,6 +206,9 @@ class OnESPollDecorator:
                 if max_findings is not None:
                     remaining = min(remaining, max_findings - findings_created)
 
+                if ingest_state is not None:
+                    ingest_state.begin_transaction()
+
                 while len(batch) < remaining:
                     try:
                         send_value = last_container_id if not batch else None
@@ -214,6 +218,8 @@ class OnESPollDecorator:
                         break
                     except ActionFailure as e:
                         e.set_action_name(action_name)
+                        if ingest_state is not None and ingest_state.in_transaction:
+                            ingest_state.rollback()
                         return self.app._adapt_action_result(
                             ActionResult(status=False, message=str(e)),
                             self.app.actions_manager,
@@ -221,6 +227,8 @@ class OnESPollDecorator:
                     except Exception as e:
                         self.app.actions_manager.add_exception(e)
                         logger.error(f"Error during finding processing: {e!s}")
+                        if ingest_state is not None and ingest_state.in_transaction:
+                            ingest_state.rollback()
                         return self.app._adapt_action_result(
                             ActionResult(status=False, message=str(e)),
                             self.app.actions_manager,
@@ -236,6 +244,8 @@ class OnESPollDecorator:
                     batch.append(item)
 
                 if not batch:
+                    if ingest_state is not None and ingest_state.in_transaction:
+                        ingest_state.commit()
                     break
 
                 pre_created_containers: dict[int, int] = {}
@@ -328,13 +338,27 @@ class OnESPollDecorator:
                     )
                 except Exception as e:
                     logger.error(f"Failed to bulk create findings: {e}")
+                    if ingest_state is not None and ingest_state.in_transaction:
+                        ingest_state.rollback()
+                    for cid in pre_created_containers.values():
+                        try:
+                            soar.container.delete(cid)
+                        except Exception as del_err:
+                            logger.warning(
+                                f"Failed to clean up container {cid}: {del_err}"
+                            )
+                    msg = (
+                        f"Failed to bulk create findings: {e}. "
+                        f"{findings_created} finding(s) created before failure. "
+                        f"The failed batch ({len(batch)} finding(s)) will be retried on the next poll."
+                    )
                     return self.app._adapt_action_result(
-                        ActionResult(
-                            status=False,
-                            message=f"Failed to bulk create findings: {e}",
-                        ),
+                        ActionResult(status=False, message=msg),
                         self.app.actions_manager,
                     )
+
+                if ingest_state is not None and ingest_state.in_transaction:
+                    ingest_state.commit()
 
                 bulk_errors = bulk_response.get("errors", [])
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -618,6 +618,16 @@ def mock_post_container(respx_mock):
 
 @pytest.fixture
 @pytest.mark.respx
+def mock_delete_container(respx_mock):
+    """Fixture to mock DELETE requests to delete containers."""
+    mock_route = respx_mock.delete(re.compile(r".*/rest/container/\d+/?$")).mock(
+        return_value=Response(200, json={"message": "Container deleted"})
+    )
+    return mock_route
+
+
+@pytest.fixture
+@pytest.mark.respx
 def mock_post_vault(respx_mock):
     """Fixture to mock POST requests to add attachments to vault."""
     mock_route = respx_mock.post(re.compile(r".*/rest/container_attachment/?$")).mock(

--- a/tests/interfaces/test_container_interface.py
+++ b/tests/interfaces/test_container_interface.py
@@ -141,6 +141,45 @@ def test_create_container_locally(app_with_action: App, app_connector):
     assert result
 
 
+def test_delete_container(app_connector, mock_delete_container):
+    app_connector.container.delete(1)
+    assert mock_delete_container.called
+
+
+def test_delete_container_failed(app_connector, mock_delete_container):
+    mock_delete_container.side_effect = RequestError("Failed to delete container")
+
+    with pytest.raises(SoarAPIError):
+        app_connector.container.delete(1)
+
+
+def test_delete_container_locally(app_with_action: App, app_connector):
+    app_connector.client.headers.pop("X-CSRFToken")
+
+    @app_with_action.action()
+    def action_function(params: Params, soar: SOARClient) -> ActionOutput:
+        container = {
+            "name": "test container",
+            "description": "test description",
+            "label": "events",
+            "asset_id": "1",
+            "artifacts": [],
+        }
+        container_id = soar.container.create(container)
+        soar.container.delete(container_id)
+        return ActionOutput()
+
+    result = action_function(Params(), soar=app_connector)
+    assert result
+
+
+def test_delete_container_locally_not_found(app_with_action: App, app_connector):
+    app_connector.client.headers.pop("X-CSRFToken")
+
+    with pytest.raises(SoarAPIError):
+        app_connector.container.delete(999)
+
+
 def test_container_rest_call_failed(app_connector, mock_post_container):
     mock_post_container.side_effect = RequestError("Failed to create container")
 

--- a/tests/test_asset_state.py
+++ b/tests/test_asset_state.py
@@ -69,6 +69,73 @@ def test_state_is_encrypted(example_state: AssetState):
         json.loads(raw_state)
 
 
+def test_transaction_commit_persists(example_state: AssetState):
+    example_state.put_all({"key": "original"})
+
+    example_state.begin_transaction()
+    example_state["key"] = "updated"
+    example_state["new_key"] = "new_value"
+
+    # Backend still has the original value during transaction
+    raw_state = example_state.backend.load_state() or {}
+    from soar_sdk.shims.phantom.encryption_helper import encryption_helper
+
+    decrypted = json.loads(
+        encryption_helper.decrypt(
+            raw_state[example_state.state_key], example_state.asset_id
+        )
+    )
+    assert decrypted == {"key": "original"}
+
+    example_state.commit()
+
+    assert example_state.get_all() == {"key": "updated", "new_key": "new_value"}
+
+
+def test_transaction_rollback_discards(example_state: AssetState):
+    example_state.put_all({"key": "original"})
+
+    example_state.begin_transaction()
+    example_state["key"] = "should_be_discarded"
+    example_state["extra"] = "also_discarded"
+    example_state.rollback()
+
+    assert example_state.get_all() == {"key": "original"}
+
+
+def test_transaction_reads_see_buffered_writes(example_state: AssetState):
+    example_state.put_all({"a": 1})
+
+    example_state.begin_transaction()
+    example_state["b"] = 2
+    assert example_state["b"] == 2
+    assert example_state.get_all() == {"a": 1, "b": 2}
+    example_state.rollback()
+
+
+def test_transaction_double_begin_raises(example_state: AssetState):
+    example_state.begin_transaction()
+    with pytest.raises(RuntimeError, match="already active"):
+        example_state.begin_transaction()
+    example_state.rollback()
+
+
+def test_commit_without_transaction_raises(example_state: AssetState):
+    with pytest.raises(RuntimeError, match="No active transaction"):
+        example_state.commit()
+
+
+def test_rollback_without_transaction_raises(example_state: AssetState):
+    with pytest.raises(RuntimeError, match="No active transaction"):
+        example_state.rollback()
+
+
+def test_writes_outside_transaction_persist_immediately(example_state: AssetState):
+    example_state["key"] = "persisted"
+    assert example_state.get_all() == {"key": "persisted"}
+    assert not example_state.in_transaction
+
+
 def test_get_all_with_force_reload(example_state: AssetState):
     example_state.put_all({"key": "original_value"})
 

--- a/tests/test_es_on_poll.py
+++ b/tests/test_es_on_poll.py
@@ -5,6 +5,7 @@ import pytest
 import pytest_mock
 
 from soar_sdk.app import App
+from soar_sdk.asset_state import AssetState
 from soar_sdk.exceptions import ActionFailure
 from soar_sdk.models.finding import Finding, FindingAttachment, FindingEmail
 from soar_sdk.params import OnESPollParams
@@ -726,6 +727,234 @@ def test_es_on_poll_create_findings_bulk_failure(
     assert result is False
 
 
+def test_es_on_poll_bulk_failure_cleans_up_containers(
+    app_with_action: App, mocker: pytest_mock.MockerFixture
+):
+    """Test on_es_poll deletes pre-created containers when create_findings_bulk fails."""
+    mocker.patch.object(
+        app_with_action.soar_client,
+        "create_findings_bulk",
+        side_effect=Exception("API error"),
+    )
+    mocker.patch.object(
+        app_with_action.actions_manager,
+        "save_container",
+        return_value=(True, "ok", 99),
+    )
+    vault_mock = MagicMock()
+    vault_mock.create_attachment.return_value = "vault-abc123"
+    mocker.patch.object(
+        type(app_with_action.soar_client),
+        "vault",
+        new_callable=lambda: property(lambda self: vault_mock),
+    )
+    container_mock = MagicMock()
+    mocker.patch.object(
+        type(app_with_action.soar_client),
+        "container",
+        new_callable=lambda: property(lambda self: container_mock),
+    )
+    mock_asset_ingest_config(mocker, app_with_action, {"es_security_domain": "threat"})
+
+    @app_with_action.on_es_poll()
+    def on_es_poll_function(
+        params: OnESPollParams, client=None
+    ) -> Generator[Finding, int | None]:
+        yield Finding(
+            rule_title="Phishing Email",
+            attachments=[
+                FindingAttachment(
+                    file_name="email.eml", data=b"raw content", is_raw_email=True
+                )
+            ],
+        )
+
+    params = OnESPollParams(start_time=0, end_time=1)
+    result = on_es_poll_function(params, client=app_with_action.soar_client)
+    assert result is False
+    container_mock.delete.assert_called_once_with(99)
+
+
+def test_es_on_poll_bulk_failure_cleanup_tolerates_delete_errors(
+    app_with_action: App, mocker: pytest_mock.MockerFixture
+):
+    """Test on_es_poll still returns failure even if container cleanup fails."""
+    mocker.patch.object(
+        app_with_action.soar_client,
+        "create_findings_bulk",
+        side_effect=Exception("API error"),
+    )
+    mocker.patch.object(
+        app_with_action.actions_manager,
+        "save_container",
+        return_value=(True, "ok", 99),
+    )
+    vault_mock = MagicMock()
+    vault_mock.create_attachment.return_value = "vault-abc123"
+    mocker.patch.object(
+        type(app_with_action.soar_client),
+        "vault",
+        new_callable=lambda: property(lambda self: vault_mock),
+    )
+    container_mock = MagicMock()
+    container_mock.delete.side_effect = Exception("Delete failed")
+    mocker.patch.object(
+        type(app_with_action.soar_client),
+        "container",
+        new_callable=lambda: property(lambda self: container_mock),
+    )
+    mock_asset_ingest_config(mocker, app_with_action, {"es_security_domain": "threat"})
+
+    @app_with_action.on_es_poll()
+    def on_es_poll_function(
+        params: OnESPollParams, client=None
+    ) -> Generator[Finding, int | None]:
+        yield Finding(
+            rule_title="Phishing Email",
+            attachments=[
+                FindingAttachment(
+                    file_name="email.eml", data=b"raw content", is_raw_email=True
+                )
+            ],
+        )
+
+    params = OnESPollParams(start_time=0, end_time=1)
+    result = on_es_poll_function(params, client=app_with_action.soar_client)
+    assert result is False
+    container_mock.delete.assert_called_once_with(99)
+
+
+def test_es_on_poll_bulk_failure_rolls_back_ingest_state(
+    app_with_action: App, mocker: pytest_mock.MockerFixture
+):
+    """Test that ingest_state changes are rolled back when create_findings_bulk fails."""
+    mocker.patch.object(
+        app_with_action.soar_client,
+        "create_findings_bulk",
+        side_effect=Exception("API error"),
+    )
+    mock_asset_ingest_config(mocker, app_with_action, {"es_security_domain": "threat"})
+
+    ingest_state = AssetState(app_with_action.actions_manager, "ingest", "1")
+    ingest_state.put_all({"es_next_muid": 1})
+    app_with_action.asset._ingest_state = ingest_state
+
+    @app_with_action.on_es_poll()
+    def on_es_poll_function(
+        params: OnESPollParams, client=None
+    ) -> Generator[Finding, int | None]:
+        state = app_with_action.asset.ingest_state
+        state["es_next_muid"] = 100
+        yield Finding(rule_title="Test Finding")
+
+    params = OnESPollParams(start_time=0, end_time=1)
+    result = on_es_poll_function(params, client=app_with_action.soar_client)
+    assert result is False
+    assert ingest_state.get_all() == {"es_next_muid": 1}
+
+
+def test_es_on_poll_success_commits_ingest_state(
+    app_with_action: App, mocker: pytest_mock.MockerFixture
+):
+    """Test that ingest_state changes are committed when create_findings_bulk succeeds."""
+    mocker.patch.object(
+        app_with_action.soar_client,
+        "create_findings_bulk",
+        return_value=BULK_RESPONSE,
+    )
+    mock_asset_ingest_config(mocker, app_with_action, {"es_security_domain": "threat"})
+
+    ingest_state = AssetState(app_with_action.actions_manager, "ingest", "1")
+    ingest_state.put_all({"es_next_muid": 1})
+    app_with_action.asset._ingest_state = ingest_state
+
+    @app_with_action.on_es_poll()
+    def on_es_poll_function(
+        params: OnESPollParams, client=None
+    ) -> Generator[Finding, int | None]:
+        state = app_with_action.asset.ingest_state
+        state["es_next_muid"] = 100
+        yield Finding(rule_title="Test Finding")
+
+    params = OnESPollParams(start_time=0, end_time=1)
+    result = on_es_poll_function(params, client=app_with_action.soar_client)
+    assert result is True
+    assert ingest_state.get_all() == {"es_next_muid": 100}
+
+
+def test_es_on_poll_action_failure_rolls_back_ingest_state(
+    app_with_action: App, mocker: pytest_mock.MockerFixture
+):
+    """Test that ingest_state is rolled back when ActionFailure is raised during iteration."""
+    mock_asset_ingest_config(mocker, app_with_action, {"es_security_domain": "threat"})
+
+    ingest_state = AssetState(app_with_action.actions_manager, "ingest", "1")
+    ingest_state.put_all({"es_next_muid": 1})
+    app_with_action.asset._ingest_state = ingest_state
+
+    @app_with_action.on_es_poll()
+    def on_es_poll_function(
+        params: OnESPollParams, client=None
+    ) -> Generator[Finding, int | None]:
+        state = app_with_action.asset.ingest_state
+        state["es_next_muid"] = 999
+        raise ActionFailure("Something went wrong")
+        yield
+
+    params = OnESPollParams(start_time=0, end_time=1)
+    result = on_es_poll_function(params, client=app_with_action.soar_client)
+    assert result is False
+    assert ingest_state.get_all() == {"es_next_muid": 1}
+
+
+def test_es_on_poll_generator_exception_rolls_back_ingest_state(
+    app_with_action: App, mocker: pytest_mock.MockerFixture
+):
+    """Test that ingest_state is rolled back when a generic exception is raised during iteration."""
+    mock_asset_ingest_config(mocker, app_with_action, {"es_security_domain": "threat"})
+
+    ingest_state = AssetState(app_with_action.actions_manager, "ingest", "1")
+    ingest_state.put_all({"es_next_muid": 1})
+    app_with_action.asset._ingest_state = ingest_state
+
+    @app_with_action.on_es_poll()
+    def on_es_poll_function(
+        params: OnESPollParams, client=None
+    ) -> Generator[Finding, int | None]:
+        state = app_with_action.asset.ingest_state
+        state["es_next_muid"] = 999
+        raise ValueError("Unexpected error")
+        yield
+
+    params = OnESPollParams(start_time=0, end_time=1)
+    result = on_es_poll_function(params, client=app_with_action.soar_client)
+    assert result is False
+    assert ingest_state.get_all() == {"es_next_muid": 1}
+
+
+def test_es_on_poll_empty_generator_commits_ingest_state(
+    app_with_action: App, mocker: pytest_mock.MockerFixture
+):
+    """Test that ingest_state transaction is properly handled when generator yields nothing."""
+    mock_asset_ingest_config(mocker, app_with_action, {"es_security_domain": "threat"})
+
+    ingest_state = AssetState(app_with_action.actions_manager, "ingest", "1")
+    ingest_state.put_all({"es_next_muid": 1})
+    app_with_action.asset._ingest_state = ingest_state
+
+    @app_with_action.on_es_poll()
+    def on_es_poll_function(
+        params: OnESPollParams, client=None
+    ) -> Generator[Finding, int | None]:
+        return
+        yield
+
+    params = OnESPollParams(start_time=0, end_time=1)
+    result = on_es_poll_function(params, client=app_with_action.soar_client)
+    assert result is True
+    assert ingest_state.get_all() == {"es_next_muid": 1}
+
+
 def test_es_on_poll_vault_upload_failure_continues(
     app_with_action: App, mocker: pytest_mock.MockerFixture
 ):
@@ -1214,3 +1443,105 @@ def test_es_on_poll_vault_link_fallback_when_system_info_fails(
     assert finding_payload["email"]["attachments"][0]["url"] == (
         "https://fallback.soar.local/rest/download_attachment?vault_id=vault-abc123"
     )
+
+
+def _clear_ingest_state(app: App) -> None:
+    app.asset._ingest_state = None
+
+
+def test_es_on_poll_no_ingest_state_success(
+    app_with_action: App, mocker: pytest_mock.MockerFixture
+):
+    """Test on_es_poll succeeds without ingest state."""
+    mocker.patch.object(
+        app_with_action.soar_client,
+        "create_findings_bulk",
+        return_value=BULK_RESPONSE,
+    )
+    mock_asset_ingest_config(mocker, app_with_action, {"es_security_domain": "threat"})
+    _clear_ingest_state(app_with_action)
+
+    @app_with_action.on_es_poll()
+    def on_es_poll_function(
+        params: OnESPollParams, client=None
+    ) -> Generator[Finding, int | None]:
+        yield Finding(rule_title="Test Finding")
+
+    params = OnESPollParams(start_time=0, end_time=1)
+    assert on_es_poll_function(params, client=app_with_action.soar_client) is True
+
+
+def test_es_on_poll_no_ingest_state_bulk_failure(
+    app_with_action: App, mocker: pytest_mock.MockerFixture
+):
+    """Test on_es_poll handles bulk failure without ingest state."""
+    mocker.patch.object(
+        app_with_action.soar_client,
+        "create_findings_bulk",
+        side_effect=Exception("API error"),
+    )
+    mock_asset_ingest_config(mocker, app_with_action, {"es_security_domain": "threat"})
+    _clear_ingest_state(app_with_action)
+
+    @app_with_action.on_es_poll()
+    def on_es_poll_function(
+        params: OnESPollParams, client=None
+    ) -> Generator[Finding, int | None]:
+        yield Finding(rule_title="Test Finding")
+
+    params = OnESPollParams(start_time=0, end_time=1)
+    assert on_es_poll_function(params, client=app_with_action.soar_client) is False
+
+
+def test_es_on_poll_no_ingest_state_action_failure(
+    app_with_action: App, mocker: pytest_mock.MockerFixture
+):
+    """Test on_es_poll handles ActionFailure without ingest state."""
+    mock_asset_ingest_config(mocker, app_with_action, {"es_security_domain": "threat"})
+    _clear_ingest_state(app_with_action)
+
+    @app_with_action.on_es_poll()
+    def on_es_poll_function(
+        params: OnESPollParams, client=None
+    ) -> Generator[Finding, int | None]:
+        raise ActionFailure("fail")
+        yield
+
+    params = OnESPollParams(start_time=0, end_time=1)
+    assert on_es_poll_function(params, client=app_with_action.soar_client) is False
+
+
+def test_es_on_poll_no_ingest_state_generator_exception(
+    app_with_action: App, mocker: pytest_mock.MockerFixture
+):
+    """Test on_es_poll handles generator exception without ingest state."""
+    mock_asset_ingest_config(mocker, app_with_action, {"es_security_domain": "threat"})
+    _clear_ingest_state(app_with_action)
+
+    @app_with_action.on_es_poll()
+    def on_es_poll_function(
+        params: OnESPollParams, client=None
+    ) -> Generator[Finding, int | None]:
+        raise ValueError("unexpected")
+        yield
+
+    params = OnESPollParams(start_time=0, end_time=1)
+    assert on_es_poll_function(params, client=app_with_action.soar_client) is False
+
+
+def test_es_on_poll_no_ingest_state_empty_generator(
+    app_with_action: App, mocker: pytest_mock.MockerFixture
+):
+    """Test on_es_poll handles empty generator without ingest state."""
+    mock_asset_ingest_config(mocker, app_with_action, {"es_security_domain": "threat"})
+    _clear_ingest_state(app_with_action)
+
+    @app_with_action.on_es_poll()
+    def on_es_poll_function(
+        params: OnESPollParams, client=None
+    ) -> Generator[Finding, int | None]:
+        return
+        yield
+
+    params = OnESPollParams(start_time=0, end_time=1)
+    assert on_es_poll_function(params, client=app_with_action.soar_client) is True


### PR DESCRIPTION
[PAPP-37701](https://splunk.atlassian.net/browse/PAPP-37701)
- Add functionality to delete stranded containers on failed ES finding batch create
- Fix state management via state transactions so we won't move polling state unless batch is successful