### PR TITLE
fix(cli): use correct `__all__` syntax in generated `__init__.py`

### DIFF
--- a/src/soar_sdk/cli/init/cli.py
+++ b/src/soar_sdk/cli/init/cli.py
@@ -142,7 +142,7 @@ def init_sdk_app(
     rprint("[blue]Creating app directory structure")
     src_dir = app_dir / "src"
     src_dir.mkdir()
-    (src_dir / "__init__.py").write_text("from . import app\n\n__ALL__ = [app]\n")
+    (src_dir / "__init__.py").write_text('from . import app\n\n__all__ = ["app"]\n')
 
     shutil.copy(
         APP_INIT_TEMPLATES / "basic_app/.pre-commit-config.yaml",

--- a/tests/example_app/src/__init__.py
+++ b/tests/example_app/src/__init__.py
@@ -1,3 +1,3 @@
 from . import app
 
-__ALL__ = [app]
+__all__ = ["app"]

--- a/tests/example_app_with_oauth/src/__init__.py
+++ b/tests/example_app_with_oauth/src/__init__.py
@@ -1,3 +1,3 @@
 from . import app
 
-__ALL__ = [app]
+__all__ = ["app"]

--- a/tests/example_app_with_webhook/src/__init__.py
+++ b/tests/example_app_with_webhook/src/__init__.py
@@ -1,3 +1,3 @@
 from . import app
 
-__ALL__ = [app]
+__all__ = ["app"]


### PR DESCRIPTION
## Features
List any new features you've added to the SDK:
 -

## Bug Fixes
Describe any bugs you've fixed. Link to the relevant GitHub Issues, if any:
 - The `init` command was generating `__ALL__ = [app]` which is invalid Python — `__ALL__` is not recognized and `[app]` references the module object instead of a string. Changed to `__all__ = ["app"]` so wildcard imports work correctly. Also fixed the same issue in test fixtures.


## Pull Request Checklist
 - [x] I have added or updated unit tests where appropriate.
 - [ ] I have updated documentation and example apps where appropriate.
 - [ ] My commit messages adhere to the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard.
 - [ ] All GitHub Actions and Pre-Commit checks have completed successfully.

## Legal Notice

By submitting a Contribution to this Work, You agree that Your Contribution is made subject to the primary license in the Apache 2.0 license (https://www.apache.org/licenses/LICENSE-2.0.txt). In addition, You represent that: (i) You are the copyright owner of the Contribution or (ii) You have the requisite rights to make the Contribution.

### Definitions:

"You" shall mean: (i) yourself if you are making a Contribution on your own behalf; or (ii) your company, if you are making a Contribution on behalf of your company. If you are making a Contribution on behalf of your company, you represent that you have the requisite authority to do so.

"Contribution" shall mean any original work of authorship, including any modifications or additions to an existing work, that is intentionally submitted by You for inclusion in, or documentation of, this project/repository. For the purposes of this definition, "submitted" means any form of electronic, verbal, or written communication submitted for inclusion in this project/repository, including but not limited to communication on electronic mailing lists, source code control systems, and issue tracking systems that are managed by, or on behalf of, the maintainers of the project/repository.

"Work" shall mean the collective software, content, and documentation in this project/repository.



Closes #202
