### PR TITLE
fix: use correct return type for `vault_add` shim

### DIFF
--- a/src/soar_sdk/shims/phantom/vault.py
+++ b/src/soar_sdk/shims/phantom/vault.py
@@ -1,5 +1,4 @@
-from collections.abc import Callable
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any, Protocol, TypedDict, cast
 
 if TYPE_CHECKING:
     from soar_sdk.abstract import SOARClient
@@ -8,8 +7,70 @@ from datetime import UTC
 
 from soar_sdk.exceptions import SoarAPIError
 
+VaultAttachmentRecord = dict[str, Any]
+
+
+class VaultResponse(TypedDict, total=False):
+    failed: bool
+    succeeded: bool
+    message: str
+    vault_id: str
+
+
 VaultAddResult = tuple[bool, str, str | None]
-VaultAddCallable = Callable[[int, str, str, dict[str, str] | None], VaultAddResult]
+VaultInfoResult = tuple[bool, str, list[VaultAttachmentRecord]]
+VaultDeleteResult = tuple[bool, str, list[str]]
+
+
+class VaultPlatformAPI(Protocol):
+    def get_vault_tmp_dir(self) -> str: ...
+
+    def create_attachment(
+        self,
+        file_content: str | bytes,
+        container_id: int,
+        file_name: str,
+        metadata: dict[str, str] | None = None,
+    ) -> VaultResponse: ...
+
+
+class VaultAddCallable(Protocol):
+    def __call__(
+        self,
+        container_id: int,
+        file_location: str,
+        file_name: str,
+        metadata: dict[str, str] | None = None,
+    ) -> VaultAddResult: ...
+
+
+class VaultInfoCallable(Protocol):
+    def __call__(
+        self,
+        vault_id: str | None = None,
+        file_name: str | None = None,
+        container_id: int | None = None,
+        *,
+        download_file: bool = True,
+    ) -> VaultInfoResult: ...
+
+
+class VaultDeleteCallable(Protocol):
+    def __call__(
+        self,
+        *,
+        vault_id: str | None = None,
+        file_name: str | None = None,
+        container_id: int | None = None,
+        remove_all: bool = False,
+    ) -> VaultDeleteResult: ...
+
+
+def _get_vault_id(resp_json: VaultResponse, default_message: str) -> str:
+    vault_id = resp_json.get("vault_id")
+    if vault_id is None:
+        raise SoarAPIError(resp_json.get("message") or default_message)
+    return vault_id
 
 
 class VaultBase:
@@ -50,7 +111,7 @@ class VaultBase:
         file_name: str | None = None,
         container_id: int | None = None,
         download_file: bool = True,
-    ) -> list[dict[str, Any]]:
+    ) -> list[VaultAttachmentRecord]:
         """Returns vault attachments based on the provided query parameters."""
         pass
 
@@ -69,7 +130,12 @@ class VaultBase:
 PhantomVault: type[VaultBase]
 
 try:
-    from phantom.vault import Vault, vault_add, vault_delete, vault_info
+    import phantom.vault as _phantom_vault
+
+    Vault = cast(VaultPlatformAPI, _phantom_vault.Vault)
+    vault_add = cast(VaultAddCallable, _phantom_vault.vault_add)
+    vault_delete = cast(VaultDeleteCallable, _phantom_vault.vault_delete)
+    vault_info = cast(VaultInfoCallable, _phantom_vault.vault_info)
 
     _soar_is_available = True
 except ImportError:
@@ -95,7 +161,7 @@ if _soar_is_available:
             if not resp_json.get("succeeded"):
                 error_msg = resp_json.get("message", "Could not create attachment")
                 raise SoarAPIError(error_msg)
-            return resp_json["vault_id"]
+            return _get_vault_id(resp_json, "Could not create attachment")
 
         def add_attachment(
             self,
@@ -104,8 +170,7 @@ if _soar_is_available:
             file_name: str,
             metadata: dict[str, str] | None = None,
         ) -> str:
-            typed_vault_add = cast(VaultAddCallable, vault_add)
-            success, message, vault_id = typed_vault_add(
+            success, message, vault_id = vault_add(
                 container_id, file_location, file_name, metadata
             )
             if not success:
@@ -120,7 +185,7 @@ if _soar_is_available:
             file_name: str | None = None,
             container_id: int | None = None,
             download_file: bool = True,
-        ) -> list[dict[str, Any]]:
+        ) -> list[VaultAttachmentRecord]:
             success, _, attachment = vault_info(
                 vault_id, file_name, container_id, download_file=download_file
             )
@@ -187,7 +252,7 @@ else:
 
                 try:
                     response = self.soar_client.post(VAULT_ENDPOINT, json=data)
-                    resp_json = response.json()
+                    resp_json = cast(VaultResponse, response.json())
                 except Exception as e:
                     error_msg = f"Failed to add attachment to the Vault: {e}"
                     raise SoarAPIError(error_msg) from e
@@ -197,7 +262,10 @@ else:
                     error_msg = f"Failed to add attachment to the Vault: {reason}"
                     raise SoarAPIError(error_msg)
 
-                vault_id = resp_json.get("vault_id")
+                vault_id = _get_vault_id(
+                    resp_json,
+                    "Failed to add attachment to the Vault: NONE_GIVEN",
+                )
             else:
                 with tempfile.TemporaryDirectory() as temp_dir:
                     file_path = Path(temp_dir) / file_name
@@ -255,7 +323,7 @@ else:
 
                 try:
                     response = self.soar_client.post(VAULT_ENDPOINT, json=data)
-                    resp_json = response.json()
+                    resp_json = cast(VaultResponse, response.json())
                 except Exception as e:
                     error_msg = f"Failed to add attachment to the Vault: {e}"
                     raise SoarAPIError(error_msg) from e
@@ -264,7 +332,10 @@ else:
                     reason = resp_json.get("message", "NONE_GIVEN")
                     error_msg = f"Failed to add attachment to the Vault: {reason}"
                     raise SoarAPIError(error_msg)
-                vault_id = resp_json.get("vault_id")
+                vault_id = _get_vault_id(
+                    resp_json,
+                    "Failed to add attachment to the Vault: NONE_GIVEN",
+                )
             else:
                 db_id = random.randint(1, 1000000)  # noqa: S311, this number is not used in cryptographic operations
                 doc_id = random.randint(1, 1000000)  # noqa: S311, this number is not used in cryptographic operations
@@ -298,13 +369,13 @@ else:
             file_name: str | None = None,
             container_id: int | None = None,
             download_file: bool = True,
-        ) -> list[dict[str, Any]]:
+        ) -> list[VaultAttachmentRecord]:
             if not any([vault_id, file_name, container_id]):
                 raise ValueError(
                     "Must provide either vault_id, file_name or container_id when getting a file from the Vault."
                 )
 
-            results = []
+            results: list[VaultAttachmentRecord] = []
             if is_client_authenticated(self.soar_client.client):
                 query_params: dict[str, str | int] = {"pretty": ""}
                 if vault_id:
@@ -348,14 +419,14 @@ else:
             container_id: int | None = None,
             remove_all: bool = False,
         ) -> list[str]:
-            vault_enteries = self.get_attachment(vault_id, file_name, container_id)
-            if len(vault_enteries) > 1 and not remove_all:
+            vault_entries = self.get_attachment(vault_id, file_name, container_id)
+            if len(vault_entries) > 1 and not remove_all:
                 raise SoarAPIError(
                     "More than one document found with the information provided and remove_all is set to False, no vault items were deleted."
                 )
             deleted_file_names = []
             is_authenticated = is_client_authenticated(self.soar_client.client)
-            for attachment in vault_enteries:
+            for attachment in vault_entries:
                 attachment_id = attachment["vault_id"]
                 attachment_name = attachment["name"]
                 if is_authenticated:

--- a/src/soar_sdk/shims/phantom/vault.py
+++ b/src/soar_sdk/shims/phantom/vault.py
@@ -1,4 +1,5 @@
-from typing import TYPE_CHECKING, Any
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Any, cast
 
 if TYPE_CHECKING:
     from soar_sdk.abstract import SOARClient
@@ -6,6 +7,9 @@ from abc import abstractmethod
 from datetime import UTC
 
 from soar_sdk.exceptions import SoarAPIError
+
+VaultAddResult = tuple[bool, str, str | None]
+VaultAddCallable = Callable[[int, str, str, dict[str, str] | None], VaultAddResult]
 
 
 class VaultBase:
@@ -100,11 +104,15 @@ if _soar_is_available:
             file_name: str,
             metadata: dict[str, str] | None = None,
         ) -> str:
-            resp_json = vault_add(container_id, file_location, file_name, metadata)
-            if not resp_json.get("succeeded"):
-                error_msg = resp_json.get("message", "Could not add attachment")
-                raise SoarAPIError(error_msg)
-            return resp_json["vault_id"]
+            typed_vault_add = cast(VaultAddCallable, vault_add)
+            success, message, vault_id = typed_vault_add(
+                container_id, file_location, file_name, metadata
+            )
+            if not success:
+                raise SoarAPIError(message or "Could not add attachment")
+            if vault_id is None:
+                raise SoarAPIError(message or "Could not add attachment")
+            return vault_id
 
         def get_attachment(
             self,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -650,7 +650,14 @@ def mock_delete_container(respx_mock):
 def mock_post_vault(respx_mock):
     """Fixture to mock POST requests to add attachments to vault."""
     mock_route = respx_mock.post(re.compile(r".*/rest/container_attachment/?$")).mock(
-        return_value=Response(201, json={"message": "Attachment added", "id": 1})
+        return_value=Response(
+            201,
+            json={
+                "message": "Attachment added",
+                "id": 1,
+                "vault_id": "mock-vault-id",
+            },
+        )
     )
     return mock_route
 

--- a/tests/example_app/app.json
+++ b/tests/example_app/app.json
@@ -1035,6 +1035,75 @@
                     ]
                 }
             ]
+        },
+        {
+            "action": "stage vault tmp file",
+            "identifier": "stage_vault_tmp_file",
+            "description": "stage vault tmp file",
+            "type": "generic",
+            "read_only": false,
+            "versions": "EQ(*)",
+            "verbose": "",
+            "parameters": {
+                "file_name": {
+                    "order": 0,
+                    "name": "file_name",
+                    "description": "File Name",
+                    "data_type": "string",
+                    "required": true,
+                    "primary": false,
+                    "allow_list": false
+                },
+                "file_content": {
+                    "order": 1,
+                    "name": "file_content",
+                    "description": "File Content",
+                    "data_type": "string",
+                    "required": true,
+                    "primary": false,
+                    "allow_list": false
+                }
+            },
+            "output": [
+                {
+                    "data_path": "action_result.status",
+                    "data_type": "string",
+                    "example_values": [
+                        "success",
+                        "failure"
+                    ]
+                },
+                {
+                    "data_path": "action_result.message",
+                    "data_type": "string"
+                },
+                {
+                    "data_path": "action_result.parameter.file_name",
+                    "data_type": "string"
+                },
+                {
+                    "data_path": "action_result.parameter.file_content",
+                    "data_type": "string"
+                },
+                {
+                    "data_path": "action_result.data.*.file_path",
+                    "data_type": "string"
+                },
+                {
+                    "data_path": "summary.total_objects",
+                    "data_type": "numeric",
+                    "example_values": [
+                        1
+                    ]
+                },
+                {
+                    "data_path": "summary.total_objects_successful",
+                    "data_type": "numeric",
+                    "example_values": [
+                        1
+                    ]
+                }
+            ]
         }
     ],
     "pip313_dependencies": {

--- a/tests/example_app/src/app.py
+++ b/tests/example_app/src/app.py
@@ -1,5 +1,6 @@
 from collections.abc import Generator, Iterator
 from datetime import UTC, datetime
+from pathlib import Path
 from zoneinfo import ZoneInfo
 
 from soar_sdk.abstract import SOARClient
@@ -293,6 +294,15 @@ class GeneratorActionSummary(ActionOutput):
     total_iterations: int
 
 
+class StageVaultTmpFileParams(Params):
+    file_name: str
+    file_content: str
+
+
+class StageVaultTmpFileOutput(ActionOutput):
+    file_path: str
+
+
 @app.action(summary_type=GeneratorActionSummary)
 def generator_action(
     params: Params, soar: SOARClient[GeneratorActionSummary], asset: Asset
@@ -316,6 +326,16 @@ def write_state(params: Params, soar: SOARClient, asset: Asset) -> ActionOutput:
 def read_state(params: Params, soar: SOARClient, asset: Asset) -> ActionOutput:
     assert asset.cache_state == {"value": "banana"}
     return ActionOutput()
+
+
+@app.action(read_only=False)
+def stage_vault_tmp_file(
+    params: StageVaultTmpFileParams, soar: SOARClient, asset: Asset
+) -> StageVaultTmpFileOutput:
+    vault_tmp_dir = Path(soar.vault.get_vault_tmp_dir())
+    file_path = vault_tmp_dir / Path(params.file_name).name
+    file_path.write_text(params.file_content, encoding="utf-8")
+    return StageVaultTmpFileOutput(file_path=str(file_path))
 
 
 if __name__ == "__main__":

--- a/tests/integration/test_vault_client.py
+++ b/tests/integration/test_vault_client.py
@@ -1,0 +1,128 @@
+from contextlib import suppress
+from uuid import uuid4
+
+from soar_sdk.models.vault_attachment import VaultAttachment
+
+from .soar_client import AppOnStackClient
+
+
+def _get_matching_attachment(
+    client: AppOnStackClient, vault_id: str, file_name: str
+) -> VaultAttachment:
+    attachments = client.phantom.vault.get_attachment(vault_id=vault_id)
+    matching_attachments = [
+        attachment for attachment in attachments if attachment.vault_id == vault_id
+    ]
+
+    assert len(matching_attachments) == 1
+    attachment = matching_attachments[0]
+    assert attachment.name == file_name
+    return attachment
+
+
+def _delete_vault_id(client: AppOnStackClient, vault_id: str) -> list[str]:
+    return client.phantom.vault.delete_attachment(vault_id=vault_id)
+
+
+def test_vault_create_get_delete_attachment(example_app_client: AppOnStackClient):
+    container_id = example_app_client.container_id
+    assert container_id is not None
+
+    test_id = uuid4().hex
+    file_name = f"sdk-vault-create-{test_id}.txt"
+    file_content = f"vault create integration test content {test_id}"
+    metadata = {"sdk_integration_test": test_id, "operation": "create"}
+    vault_id: str | None = None
+
+    try:
+        vault_id = example_app_client.phantom.vault.create_attachment(
+            container_id=container_id,
+            file_content=file_content,
+            file_name=file_name,
+            metadata=metadata,
+        )
+
+        assert vault_id
+
+        attachment = _get_matching_attachment(example_app_client, vault_id, file_name)
+        assert attachment.container_id == container_id
+        assert attachment.metadata.get("sdk_integration_test") == test_id
+        assert attachment.metadata.get("operation") == "create"
+
+        attachments_by_name = example_app_client.phantom.vault.get_attachment(
+            file_name=file_name
+        )
+        assert any(
+            attachment.vault_id == vault_id for attachment in attachments_by_name
+        )
+
+        attachments_by_container = example_app_client.phantom.vault.get_attachment(
+            container_id=container_id
+        )
+        assert any(
+            attachment.vault_id == vault_id for attachment in attachments_by_container
+        )
+
+        deleted_vault_id = vault_id
+        deleted_file_names = _delete_vault_id(example_app_client, deleted_vault_id)
+        assert file_name in deleted_file_names
+        vault_id = None
+
+        assert (
+            example_app_client.phantom.vault.get_attachment(vault_id=deleted_vault_id)
+            == []
+        )
+    finally:
+        if vault_id is not None:
+            with suppress(Exception):
+                _delete_vault_id(example_app_client, vault_id)
+
+
+def test_vault_add_get_delete_attachment(example_app_client: AppOnStackClient):
+    container_id = example_app_client.container_id
+    assert container_id is not None
+
+    test_id = uuid4().hex
+    file_name = f"sdk-vault-add-{test_id}.txt"
+    file_content = f"vault add integration test content {test_id}"
+    metadata = {"sdk_integration_test": test_id, "operation": "add"}
+    vault_id: str | None = None
+
+    stage_result = example_app_client.run_action(
+        "stage vault tmp file",
+        {"file_name": file_name, "file_content": file_content},
+    )
+    assert stage_result.success, f"Stage vault tmp file failed: {stage_result.message}"
+
+    staged_file_path = stage_result.data["data"][0]["file_path"]
+    assert staged_file_path.endswith(file_name)
+
+    try:
+        vault_id = example_app_client.phantom.vault.add_attachment(
+            container_id=container_id,
+            file_location=staged_file_path,
+            file_name=file_name,
+            metadata=metadata,
+        )
+
+        assert vault_id
+
+        attachment = _get_matching_attachment(example_app_client, vault_id, file_name)
+        assert attachment.container_id == container_id
+        assert attachment.metadata.get("sdk_integration_test") == test_id
+        assert attachment.metadata.get("operation") == "add"
+        assert attachment.path
+
+        deleted_vault_id = vault_id
+        deleted_file_names = _delete_vault_id(example_app_client, deleted_vault_id)
+        assert file_name in deleted_file_names
+        vault_id = None
+
+        assert (
+            example_app_client.phantom.vault.get_attachment(vault_id=deleted_vault_id)
+            == []
+        )
+    finally:
+        if vault_id is not None:
+            with suppress(Exception):
+                _delete_vault_id(example_app_client, vault_id)

--- a/tests/interfaces/test_vault_interface.py
+++ b/tests/interfaces/test_vault_interface.py
@@ -1,3 +1,8 @@
+import importlib
+import sys
+import types
+from unittest.mock import MagicMock, Mock
+
 import pytest
 from httpx import RequestError, Response
 
@@ -6,8 +11,84 @@ from soar_sdk.app_client import BasicAuth
 from soar_sdk.exceptions import SoarAPIError
 
 
+@pytest.fixture
+def platform_vault(monkeypatch):
+    import soar_sdk.shims.phantom.vault as vault_shim
+
+    phantom_module = types.ModuleType("phantom")
+    phantom_vault_module = types.ModuleType("phantom.vault")
+
+    class FakeVault:
+        @staticmethod
+        def get_vault_tmp_dir():
+            return "/opt/phantom/vault/tmp"
+
+    vault_add = Mock(return_value=(True, "Attachment added", "vault-id"))
+    phantom_vault_module.Vault = FakeVault
+    phantom_vault_module.vault_add = vault_add
+    phantom_vault_module.vault_delete = Mock(return_value=(True, "", []))
+    phantom_vault_module.vault_info = Mock(return_value=(True, "", []))
+    phantom_module.vault = phantom_vault_module
+
+    with monkeypatch.context() as mp:
+        mp.setitem(sys.modules, "phantom", phantom_module)
+        mp.setitem(sys.modules, "phantom.vault", phantom_vault_module)
+        reloaded_vault_shim = importlib.reload(vault_shim)
+        yield reloaded_vault_shim, vault_add
+
+    importlib.reload(vault_shim)
+
+
 def test_vault_get_temp_dir(app_connector):
     assert app_connector.vault.get_vault_tmp_dir() == "/opt/phantom/vault/tmp"
+
+
+def test_platform_vault_add_attachment_returns_vault_id(platform_vault):
+    vault_shim, vault_add = platform_vault
+    vault = vault_shim.PhantomVault(MagicMock())
+
+    vault_id = vault.add_attachment(
+        container_id=1,
+        file_location="/opt/phantom/vault/tmp/test.txt",
+        file_name="test.txt",
+        metadata={"source": "test"},
+    )
+
+    assert vault_id == "vault-id"
+    vault_add.assert_called_once_with(
+        1,
+        "/opt/phantom/vault/tmp/test.txt",
+        "test.txt",
+        {"source": "test"},
+    )
+
+
+def test_platform_vault_add_attachment_failed_tuple(platform_vault):
+    vault_shim, vault_add = platform_vault
+    vault_add.return_value = (False, "Vault upload failed", None)
+    vault = vault_shim.PhantomVault(MagicMock())
+
+    with pytest.raises(SoarAPIError, match="Vault upload failed"):
+        vault.add_attachment(
+            container_id=1,
+            file_location="/opt/phantom/vault/tmp/test.txt",
+            file_name="test.txt",
+            metadata={},
+        )
+
+
+def test_platform_vault_add_attachment_missing_vault_id(platform_vault):
+    vault_shim, vault_add = platform_vault
+    vault_add.return_value = (True, "Vault ID missing", None)
+    vault = vault_shim.PhantomVault(MagicMock())
+
+    with pytest.raises(SoarAPIError, match="Vault ID missing"):
+        vault.add_attachment(
+            container_id=1,
+            file_location="/opt/phantom/vault/tmp/test.txt",
+            file_name="test.txt",
+            metadata={},
+        )
 
 
 def test_vault_create_attachment(app_connector, mock_post_vault):

--- a/tests/interfaces/test_vault_interface.py
+++ b/tests/interfaces/test_vault_interface.py
@@ -18,23 +18,33 @@ def platform_vault(monkeypatch):
     phantom_module = types.ModuleType("phantom")
     phantom_vault_module = types.ModuleType("phantom.vault")
 
-    class FakeVault:
-        @staticmethod
-        def get_vault_tmp_dir():
-            return "/opt/phantom/vault/tmp"
-
+    fake_vault = MagicMock()
+    fake_vault.get_vault_tmp_dir.return_value = "/opt/phantom/vault/tmp"
+    fake_vault.create_attachment.return_value = {
+        "succeeded": True,
+        "message": "Attachment created",
+        "vault_id": "created-vault-id",
+    }
     vault_add = Mock(return_value=(True, "Attachment added", "vault-id"))
-    phantom_vault_module.Vault = FakeVault
+    vault_delete = Mock(return_value=(True, "Attachment deleted", ["test.txt"]))
+    vault_info = Mock(return_value=(True, "", [{"vault_id": "vault-id"}]))
+    phantom_vault_module.Vault = fake_vault
     phantom_vault_module.vault_add = vault_add
-    phantom_vault_module.vault_delete = Mock(return_value=(True, "", []))
-    phantom_vault_module.vault_info = Mock(return_value=(True, "", []))
+    phantom_vault_module.vault_delete = vault_delete
+    phantom_vault_module.vault_info = vault_info
     phantom_module.vault = phantom_vault_module
 
     with monkeypatch.context() as mp:
         mp.setitem(sys.modules, "phantom", phantom_module)
         mp.setitem(sys.modules, "phantom.vault", phantom_vault_module)
         reloaded_vault_shim = importlib.reload(vault_shim)
-        yield reloaded_vault_shim, vault_add
+        yield types.SimpleNamespace(
+            vault_shim=reloaded_vault_shim,
+            vault=fake_vault,
+            vault_add=vault_add,
+            vault_delete=vault_delete,
+            vault_info=vault_info,
+        )
 
     importlib.reload(vault_shim)
 
@@ -44,8 +54,7 @@ def test_vault_get_temp_dir(app_connector):
 
 
 def test_platform_vault_add_attachment_returns_vault_id(platform_vault):
-    vault_shim, vault_add = platform_vault
-    vault = vault_shim.PhantomVault(MagicMock())
+    vault = platform_vault.vault_shim.PhantomVault(MagicMock())
 
     vault_id = vault.add_attachment(
         container_id=1,
@@ -55,7 +64,7 @@ def test_platform_vault_add_attachment_returns_vault_id(platform_vault):
     )
 
     assert vault_id == "vault-id"
-    vault_add.assert_called_once_with(
+    platform_vault.vault_add.assert_called_once_with(
         1,
         "/opt/phantom/vault/tmp/test.txt",
         "test.txt",
@@ -64,9 +73,8 @@ def test_platform_vault_add_attachment_returns_vault_id(platform_vault):
 
 
 def test_platform_vault_add_attachment_failed_tuple(platform_vault):
-    vault_shim, vault_add = platform_vault
-    vault_add.return_value = (False, "Vault upload failed", None)
-    vault = vault_shim.PhantomVault(MagicMock())
+    platform_vault.vault_add.return_value = (False, "Vault upload failed", None)
+    vault = platform_vault.vault_shim.PhantomVault(MagicMock())
 
     with pytest.raises(SoarAPIError, match="Vault upload failed"):
         vault.add_attachment(
@@ -78,9 +86,8 @@ def test_platform_vault_add_attachment_failed_tuple(platform_vault):
 
 
 def test_platform_vault_add_attachment_missing_vault_id(platform_vault):
-    vault_shim, vault_add = platform_vault
-    vault_add.return_value = (True, "Vault ID missing", None)
-    vault = vault_shim.PhantomVault(MagicMock())
+    platform_vault.vault_add.return_value = (True, "Vault ID missing", None)
+    vault = platform_vault.vault_shim.PhantomVault(MagicMock())
 
     with pytest.raises(SoarAPIError, match="Vault ID missing"):
         vault.add_attachment(
@@ -89,6 +96,106 @@ def test_platform_vault_add_attachment_missing_vault_id(platform_vault):
             file_name="test.txt",
             metadata={},
         )
+
+
+def test_platform_vault_create_attachment_returns_vault_id(platform_vault):
+    vault = platform_vault.vault_shim.PhantomVault(MagicMock())
+
+    vault_id = vault.create_attachment(
+        container_id=1,
+        file_content="test content",
+        file_name="test.txt",
+        metadata={"source": "test"},
+    )
+
+    assert vault_id == "created-vault-id"
+    platform_vault.vault.create_attachment.assert_called_once_with(
+        "test content",
+        1,
+        "test.txt",
+        {"source": "test"},
+    )
+
+
+def test_platform_vault_create_attachment_failed_response(platform_vault):
+    platform_vault.vault.create_attachment.return_value = {
+        "succeeded": False,
+        "message": "Vault create failed",
+    }
+    vault = platform_vault.vault_shim.PhantomVault(MagicMock())
+
+    with pytest.raises(SoarAPIError, match="Vault create failed"):
+        vault.create_attachment(
+            container_id=1,
+            file_content="test content",
+            file_name="test.txt",
+            metadata={},
+        )
+
+
+def test_platform_vault_create_attachment_missing_vault_id(platform_vault):
+    platform_vault.vault.create_attachment.return_value = {
+        "succeeded": True,
+        "message": "Vault ID missing",
+    }
+    vault = platform_vault.vault_shim.PhantomVault(MagicMock())
+
+    with pytest.raises(SoarAPIError, match="Vault ID missing"):
+        vault.create_attachment(
+            container_id=1,
+            file_content="test content",
+            file_name="test.txt",
+            metadata={},
+        )
+
+
+def test_platform_vault_get_attachment_returns_attachments(platform_vault):
+    vault = platform_vault.vault_shim.PhantomVault(MagicMock())
+
+    attachments = vault.get_attachment(
+        vault_id="vault-id",
+        file_name="test.txt",
+        container_id=1,
+        download_file=False,
+    )
+
+    assert attachments == [{"vault_id": "vault-id"}]
+    platform_vault.vault_info.assert_called_once_with(
+        "vault-id",
+        "test.txt",
+        1,
+        download_file=False,
+    )
+
+
+def test_platform_vault_get_attachment_failed_tuple(platform_vault):
+    platform_vault.vault_info.return_value = (False, "Lookup failed", [])
+    vault = platform_vault.vault_shim.PhantomVault(MagicMock())
+
+    with pytest.raises(SoarAPIError, match="Could not retrieve attachment"):
+        vault.get_attachment(vault_id="vault-id")
+
+
+def test_platform_vault_delete_attachment_returns_file_names(platform_vault):
+    vault = platform_vault.vault_shim.PhantomVault(MagicMock())
+
+    deleted_file_names = vault.delete_attachment(vault_id="vault-id")
+
+    assert deleted_file_names == ["test.txt"]
+    platform_vault.vault_delete.assert_called_once_with(
+        vault_id="vault-id",
+        file_name=None,
+        container_id=None,
+        remove_all=False,
+    )
+
+
+def test_platform_vault_delete_attachment_failed_tuple(platform_vault):
+    platform_vault.vault_delete.return_value = (False, "Delete failed", [])
+    vault = platform_vault.vault_shim.PhantomVault(MagicMock())
+
+    with pytest.raises(SoarAPIError, match="Delete failed"):
+        vault.delete_attachment(vault_id="vault-id")
 
 
 def test_vault_create_attachment(app_connector, mock_post_vault):


### PR DESCRIPTION
## Features
List any new features you've added to the SDK:
 -

## Bug Fixes
Describe any bugs you've fixed. Link to the relevant GitHub Issues, if any:
 - Update the `vault_add` shim and its callers to use the correct return type, matching the tuple returned by the platform.
 - Add explicit return types and integration tests for all Vault methods.

## Pull Request Checklist
 - [x] I have added or updated unit tests where appropriate.
 - [x] I have updated documentation and example apps where appropriate.
 - [x] My commit messages adhere to the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard.
 - [x] All GitHub Actions and Pre-Commit checks have completed successfully.

## Legal Notice

By submitting a Contribution to this Work, You agree that Your Contribution is made subject to the primary license in the Apache 2.0 license (https://www.apache.org/licenses/LICENSE-2.0.txt). In addition, You represent that: (i) You are the copyright owner of the Contribution or (ii) You have the requisite rights to make the Contribution.

### Definitions:

"You" shall mean: (i) yourself if you are making a Contribution on your own behalf; or (ii) your company, if you are making a Contribution on behalf of your company. If you are making a Contribution on behalf of your company, you represent that you have the requisite authority to do so.

"Contribution" shall mean any original work of authorship, including any modifications or additions to an existing work, that is intentionally submitted by You for inclusion in, or documentation of, this project/repository. For the purposes of this definition, "submitted" means any form of electronic, verbal, or written communication submitted for inclusion in this project/repository, including but not limited to communication on electronic mailing lists, source code control systems, and issue tracking systems that are managed by, or on behalf of, the maintainers of the project/repository.

"Work" shall mean the collective software, content, and documentation in this project/repository.
