### PR TITLE
fix: sdk app usage with modern AB

### DIFF
--- a/src/soar_sdk/app.py
+++ b/src/soar_sdk/app.py
@@ -190,11 +190,13 @@ class App:
         self._raw_asset_config = input_data.config.get_asset_config()
 
         # Decrypt sensitive fields in the asset configuration
-        asset_id = input_data.asset_id
+        # RPC brokers ship values as ephemeral payloads keyed by dec_key, while
+        # classic backends use the asset_id as the decryption salt.
+        decryption_salt = input_data.dec_key or str(input_data.asset_id)
         for field in self.asset_cls.fields_requiring_decryption():
             if self._raw_asset_config.get(field):
                 self._raw_asset_config[field] = platform_encryption_backend.decrypt(
-                    self._raw_asset_config[field], str(asset_id)
+                    self._raw_asset_config[field], decryption_salt
                 )
 
         # Inflate timezone fields in the asset configuration

--- a/src/soar_sdk/app_client.py
+++ b/src/soar_sdk/app_client.py
@@ -8,7 +8,10 @@ from soar_sdk.abstract import JSONType, SOARClient, SOARClientAuth, SummaryType
 from soar_sdk.apis.artifact import Artifact
 from soar_sdk.apis.container import Container
 from soar_sdk.apis.vault import Vault
-from soar_sdk.shims.phantom.install_info import is_onprem_broker_install
+from soar_sdk.shims.phantom.install_info import (
+    is_onprem_broker_install,
+    is_onprem_broker_rpc_install,
+)
 
 if TYPE_CHECKING:
     pass
@@ -159,8 +162,11 @@ class AppClient(SOARClient[SummaryType]):
         # Route through broker api_proxy
         endpoint = f"/rest/broker/api_proxy{endpoint}"
 
-        # Add broker authentication headers
-        headers["ph-auth-token"] = self._broker_ph_auth_token
+        # RPC brokers use ephemeral Bearer tokens, WebSocket brokers use ph-auth-token
+        if is_onprem_broker_rpc_install():
+            headers["Authorization"] = f"Bearer {self._broker_ph_auth_token}"
+        else:
+            headers["ph-auth-token"] = self._broker_ph_auth_token
         headers["PsaasImpersonationToken"] = self._user_hash_key
 
         return endpoint, headers

--- a/src/soar_sdk/input_spec.py
+++ b/src/soar_sdk/input_spec.py
@@ -150,3 +150,13 @@ class InputSpecification(BaseModel):
     soar_auth: SoarAuth | None = None
     user_hash_key: str = ""
     broker_ph_auth_token: str = ""
+
+    @field_validator("user_session_token", mode="before")
+    @classmethod
+    def normalize_user_session_token(cls, value: str | None) -> str:
+        """Coerce a null user_session_token to an empty string.
+
+        Modern (RPC) automation brokers send the token as null when there is no
+        effective user, which the strict string field would otherwise reject.
+        """
+        return value or ""

--- a/src/soar_sdk/shims/phantom/install_info.py
+++ b/src/soar_sdk/shims/phantom/install_info.py
@@ -3,6 +3,7 @@ try:
         get_product_version,
         get_verify_ssl_setting,
         is_onprem_broker_install,
+        is_onprem_broker_rpc_install,
     )
 
     _soar_is_available = True
@@ -25,6 +26,10 @@ if TYPE_CHECKING or not _soar_is_available:
         """Mock function to simulate the behavior of is_onprem_broker_install."""
         return False
 
+    def is_onprem_broker_rpc_install() -> bool:
+        """Mock function to simulate the behavior of is_onprem_broker_rpc_install."""
+        return False
+
 
 def is_soar_available() -> bool:
     """
@@ -37,5 +42,6 @@ __all__ = [
     "get_product_version",
     "get_verify_ssl_setting",
     "is_onprem_broker_install",
+    "is_onprem_broker_rpc_install",
     "is_soar_available",
 ]

--- a/tests/test_app_client.py
+++ b/tests/test_app_client.py
@@ -195,6 +195,27 @@ def test_prepare_broker_request(mock_broker, simple_connector: AppClient):
     assert response.json() == {"version": "6.4.1"}
 
 
+@patch("soar_sdk.app_client.is_onprem_broker_rpc_install", return_value=True)
+@patch("soar_sdk.app_client.is_onprem_broker_install", return_value=True)
+@respx.mock
+def test_prepare_broker_request_rpc(mock_broker, mock_rpc, simple_connector: AppClient):
+    """Test that RPC broker requests use a Bearer token instead of ph-auth-token."""
+    simple_connector._broker_ph_auth_token = "broker-token"
+    simple_connector._user_hash_key = "hash-key"
+
+    route = respx.get("https://localhost:9999/rest/broker/api_proxy/rest/version").mock(
+        return_value=httpx.Response(200, json={"version": "6.4.1"})
+    )
+    response = simple_connector.get("/rest/version")
+
+    assert route.called
+    request = route.calls[0].request
+    assert request.headers["Authorization"] == "Bearer broker-token"
+    assert request.headers["PsaasImpersonationToken"] == "hash-key"
+    assert "ph-auth-token" not in request.headers
+    assert response.json() == {"version": "6.4.1"}
+
+
 @patch("soar_sdk.app_client.is_onprem_broker_install", return_value=True)
 @respx.mock
 def test_prepare_broker_request_adds_leading_slash(


### PR DESCRIPTION
[PSAAS-29743](https://splunk.atlassian.net/browse/PSAAS-29743)

Fixes:
- Add is_onprem_broker_rpc_install shim so the SDK can detect RPC brokers
- Use Authorization: Bearer + PsaasImpersonationToken via api_proxy for RPC brokers (not classic ph-auth-token)
- Fix user_session_token: null (RPC brokers send null and strict str rejected it)
- Decrypt asset secrets with dec_key salt on broker and fall back to asset_id for classic/CLI