### PR TITLE
Validate OAuth callback state

### DIFF
--- a/src/soar_sdk/auth/client.py
+++ b/src/soar_sdk/auth/client.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import hmac
 import secrets
 import urllib.parse
 import uuid
@@ -370,10 +371,18 @@ class SOARAssetOAuthClient:
             raise OAuthClientError("No authorization code in callback")
 
         callback_state = callback_params.get("state")
-        if callback_state:
-            state = self._load_state()
-            if state.session and state.session.state != callback_state:
-                raise OAuthClientError("State mismatch in authorization callback")
+        if not callback_state:
+            raise OAuthClientError("Missing state in authorization callback")
+
+        state = self._load_state()
+        if (
+            not state.session
+            or not state.session.auth_pending
+            or not state.session.state
+        ):
+            raise OAuthClientError("No pending authorization session")
+        if not hmac.compare_digest(state.session.state, callback_state):
+            raise OAuthClientError("State mismatch in authorization callback")
 
         return self.fetch_token_with_authorization_code(code)
 

--- a/src/soar_sdk/auth/factories.py
+++ b/src/soar_sdk/auth/factories.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from contextlib import contextmanager
+from hmac import compare_digest
 from typing import TYPE_CHECKING, Any
 
 import httpx
@@ -110,6 +111,18 @@ def create_oauth_callback_handler(
             )
 
         oauth_client = get_oauth_client(request.asset)
+        pending_session = oauth_client.get_pending_session()
+        callback_state = query_params.get("state")
+        if (
+            pending_session is None
+            or not pending_session.state
+            or not callback_state
+            or not compare_digest(pending_session.state, callback_state)
+        ):
+            return WebhookResponse.text_response(
+                content="Invalid OAuth state",
+                status_code=400,
+            )
         oauth_client.set_authorization_code(code)
 
         return WebhookResponse.text_response(

--- a/tests/test_oauth_client.py
+++ b/tests/test_oauth_client.py
@@ -576,17 +576,15 @@ class TestHandleAuthorizationCallback:
         )
         assert token.access_token == "callback_token"
 
-    @respx.mock
-    def test_handle_callback_without_state(self, oauth_client, mock_auth_state):
-        respx.post("https://auth.example.com/token").mock(
-            return_value=httpx.Response(
-                200,
-                json={"access_token": "no_state_token", "expires_in": 3600},
-            )
-        )
+    def test_handle_callback_without_state(self, oauth_client):
+        with pytest.raises(OAuthClientError, match="Missing state"):
+            oauth_client.handle_authorization_callback({"code": "auth_code"})
 
-        token = oauth_client.handle_authorization_callback({"code": "auth_code"})
-        assert token.access_token == "no_state_token"
+    def test_handle_callback_without_pending_session(self, oauth_client):
+        with pytest.raises(OAuthClientError, match="No pending authorization session"):
+            oauth_client.handle_authorization_callback(
+                {"code": "auth_code", "state": "some_state"}
+            )
 
     def test_handle_callback_with_error(self, oauth_client):
         with pytest.raises(OAuthClientError) as exc_info:

--- a/tests/test_oauth_factories.py
+++ b/tests/test_oauth_factories.py
@@ -1,3 +1,5 @@
+from unittest.mock import Mock
+
 import httpx
 import pytest
 
@@ -240,48 +242,65 @@ class TestCreateOAuthCallbackHandler:
         assert "Missing authorization code" in response.content
 
     def test_handler_stores_auth_code_on_success(self, mock_asset):
-        def get_oauth_client(asset):
-            from soar_sdk.auth.client import SOARAssetOAuthClient
-            from soar_sdk.auth.models import OAuthConfig
+        oauth_client = Mock()
+        oauth_client.get_pending_session.return_value = Mock(state="expected_state")
+        handler = create_oauth_callback_handler(lambda _asset: oauth_client)
 
-            config = OAuthConfig(
-                client_id=asset.client_id,
-                client_secret=asset.client_secret,
-                token_endpoint=asset.token_endpoint,
-            )
-            return SOARAssetOAuthClient(config, asset.auth_state)
+        class MockRequest:
+            def __init__(self):
+                self.asset = mock_asset
+                self.query = {
+                    "code": ["auth_code_123"],
+                    "state": ["expected_state"],
+                }
 
-        handler = create_oauth_callback_handler(get_oauth_client)
+        response = handler(MockRequest())
+        assert response.status_code == 200
+        assert "Authorization successful" in response.content
+        oauth_client.set_authorization_code.assert_called_once_with("auth_code_123")
+
+    @pytest.mark.parametrize(
+        ("pending_session", "callback_state"),
+        [
+            (None, "expected_state"),
+            (Mock(state=None), "expected_state"),
+            (Mock(state="expected_state"), None),
+            (Mock(state="expected_state"), "wrong_state"),
+        ],
+    )
+    def test_handler_rejects_invalid_state(
+        self, mock_asset, pending_session, callback_state
+    ):
+        oauth_client = Mock()
+        oauth_client.get_pending_session.return_value = pending_session
+        handler = create_oauth_callback_handler(lambda _asset: oauth_client)
 
         class MockRequest:
             def __init__(self):
                 self.asset = mock_asset
                 self.query = {"code": ["auth_code_123"]}
+                if callback_state is not None:
+                    self.query["state"] = [callback_state]
 
         response = handler(MockRequest())
-        assert response.status_code == 200
-        assert "Authorization successful" in response.content
+        assert response.status_code == 400
+        assert "Invalid OAuth state" in response.content
+        oauth_client.set_authorization_code.assert_not_called()
 
     def test_handler_uses_custom_success_message(self, mock_asset):
-        def get_oauth_client(asset):
-            from soar_sdk.auth.client import SOARAssetOAuthClient
-            from soar_sdk.auth.models import OAuthConfig
-
-            config = OAuthConfig(
-                client_id=asset.client_id,
-                client_secret=asset.client_secret,
-                token_endpoint=asset.token_endpoint,
-            )
-            return SOARAssetOAuthClient(config, asset.auth_state)
-
+        oauth_client = Mock()
+        oauth_client.get_pending_session.return_value = Mock(state="expected_state")
         handler = create_oauth_callback_handler(
-            get_oauth_client, success_message="Custom success!"
+            lambda _asset: oauth_client, success_message="Custom success!"
         )
 
         class MockRequest:
             def __init__(self):
                 self.asset = mock_asset
-                self.query = {"code": ["auth_code_123"]}
+                self.query = {
+                    "code": ["auth_code_123"],
+                    "state": ["expected_state"],
+                }
 
         response = handler(MockRequest())
         assert "Custom success!" in response.content


### PR DESCRIPTION
## Summary

- require callback state to match the active pending OAuth session before storing an authorization code
- reject missing state and callbacks without a pending session in the lower-level OAuth client
- compare state values with a constant-time comparison
- add regression coverage for missing, mismatched, and absent-session callbacks

## Tracking

- Parent epic: https://splunk.atlassian.net/browse/ESPM-5228
- PAPP: https://splunk.atlassian.net/browse/PAPP-37965
- Finding: https://splunk.atlassian.net/browse/PSAAS-30953
- Reference connector PR: https://github.com/splunk-soar-connectors/github/pull/41

## Quality gate

- full pre-commit suite: passed
- full pytest suite: 1,299 passed, 17 skipped
- coverage: 100%
- type checking: passed
- Python compile: passed
- security scans: optional; pass or absence is acceptable

Created entirely with Codex AI assistance.