### PR TITLE
fix: harden shared email ingestion

### DIFF
--- a/src/soar_sdk/extras/email/email_data.py
+++ b/src/soar_sdk/extras/email/email_data.py
@@ -207,6 +207,8 @@ def extract_email_body(mail: Message) -> EmailBody:
                 body.plain_text = decoded
         return body
 
+    plain_parts: list[str] = []
+    html_parts: list[str] = []
     for part in mail.walk():
         if part.is_multipart():
             continue
@@ -224,10 +226,13 @@ def extract_email_body(mail: Message) -> EmailBody:
         part_charset = _get_charset(part)
         decoded = _decode_payload(payload, part_charset)
 
-        if content_type == "text/plain" and not body.plain_text:
-            body.plain_text = decoded
-        elif content_type == "text/html" and not body.html:
-            body.html = decoded
+        if content_type == "text/plain":
+            plain_parts.append(decoded)
+        elif content_type == "text/html":
+            html_parts.append(decoded)
+
+    body.plain_text = "\n".join(plain_parts) or None
+    body.html = "\n".join(html_parts) or None
 
     return body
 

--- a/src/soar_sdk/extras/email/processor.py
+++ b/src/soar_sdk/extras/email/processor.py
@@ -1164,7 +1164,7 @@ class EmailProcessor:
             ret_val, status_string = APP_ERROR, str(e)
             logger.debug(f"save_artifact failed: {e}")
 
-        return APP_SUCCESS, ret_val
+        return ret_val, ret_val
 
     def _set_sdi(self, input_dict: dict[str, Any]) -> int:
         input_dict.pop("source_data_identifier", None)

--- a/src/soar_sdk/extras/email/processor.py
+++ b/src/soar_sdk/extras/email/processor.py
@@ -831,7 +831,12 @@ class EmailProcessor:
     def _int_process_email(
         self, rfc822_email: str, email_id: str, start_time_epoch: float
     ) -> tuple[int, str, list[dict[str, Any]]]:
-        mail = email.message_from_string(rfc822_email)
+        try:
+            mail = email.message_from_string(rfc822_email)
+        except (RecursionError, ValueError) as e:
+            message = f"Failed to parse RFC822 email: {e}"
+            logger.warning(message)
+            return APP_ERROR, message, []
 
         tmp_dir = tempfile.mkdtemp(prefix="ph_email_")
         self._tmp_dirs.append(tmp_dir)

--- a/src/soar_sdk/extras/email/processor.py
+++ b/src/soar_sdk/extras/email/processor.py
@@ -896,10 +896,13 @@ class EmailProcessor:
             return APP_ERROR, message
 
         try:
-            self._parse_results(results, container_id)
+            parse_status = self._parse_results(results, container_id)
         except Exception:
             self._del_tmp_dirs()
             raise
+
+        if parse_status == APP_ERROR:
+            return APP_ERROR, "Failed to save processed email data"
 
         return APP_SUCCESS, "Email Processed"
 
@@ -912,7 +915,8 @@ class EmailProcessor:
             for artifact in artifacts:
                 artifact["container_id"] = cid
             try:
-                _ids = self.context.soar.save_artifacts(artifacts)  # type: ignore[attr-defined]
+                for artifact in artifacts:
+                    self.context.soar.artifact.create(artifact)
                 ret_val, message = APP_SUCCESS, "Success"
                 logger.debug(
                     f"save_artifacts returns, value: {ret_val}, reason: {message}"
@@ -925,7 +929,7 @@ class EmailProcessor:
             return ret_val, message, cid
         else:
             try:
-                cid = self.context.soar.save_container(container)  # type: ignore[attr-defined]
+                cid = self.context.soar.container.create(container)
                 ret_val, message = APP_SUCCESS, "Success"
                 logger.debug(
                     f"save_container (with artifacts) returns, value: {ret_val}, reason: {message}, id: {cid}"
@@ -942,7 +946,7 @@ class EmailProcessor:
         container: dict[str, Any] | None,
         container_id: int | None,
         files: list[dict[str, Any]],
-    ) -> None:
+    ) -> int:
         using_dummy = False
 
         if container_id:
@@ -956,7 +960,7 @@ class EmailProcessor:
         elif container:
             container["artifacts"] = artifacts
         else:
-            return
+            return APP_ERROR
 
         for artifact in [
             x
@@ -973,12 +977,12 @@ class EmailProcessor:
         if ret_val == APP_ERROR:
             message = f"Failed to save ingested artifacts, error msg: {message}"
             logger.debug(message)
-            return
+            return APP_ERROR
 
         if not container_id:
             message = "save_container did not return a container_id"
             logger.debug(message)
-            return
+            return APP_ERROR
 
         vault_ids: list[str] = []
         vault_artifacts_added = 0
@@ -996,6 +1000,10 @@ class EmailProcessor:
 
             if added_to_vault:
                 vault_artifacts_added += 1
+            if ret_val == APP_ERROR:
+                return APP_ERROR
+
+        return APP_SUCCESS
 
     def _parse_results(
         self, results: list[dict[str, Any]], container_id: int | None = None
@@ -1003,6 +1011,7 @@ class EmailProcessor:
         container_count = DEFAULT_CONTAINER_COUNT
         results = results[:container_count]
 
+        parse_status = APP_SUCCESS
         for result in results:
             if container_id is None:
                 container = result.get("container")
@@ -1044,15 +1053,18 @@ class EmailProcessor:
                 if "emailGuid" in cef_artifact:
                     del cef_artifact["emailGuid"]
 
-            self._handle_save_ingested(
+            save_status = self._handle_save_ingested(
                 artifacts, container, container_id, result.get("files", [])
             )
+            if save_status == APP_ERROR:
+                parse_status = APP_ERROR
+                break
 
         for result in results:
             if result.get("temp_directory"):
                 shutil.rmtree(result["temp_directory"], ignore_errors=True)
 
-        return APP_SUCCESS
+        return parse_status
 
     def _add_vault_hashes_to_dictionary(
         self, cef_artifact: dict[str, Any], vault_id: str
@@ -1143,7 +1155,7 @@ class EmailProcessor:
             cef_artifact["parentSourceDataIdentifier"] = self._guid_to_hash[parent_guid]
 
         try:
-            artifact_id_result = self.context.soar.save_artifact(artifact)  # type: ignore[attr-defined]
+            artifact_id_result = self.context.soar.artifact.create(artifact)
             ret_val, status_string = APP_SUCCESS, "Success"
             logger.debug(
                 f"save_artifact returns, value: {ret_val}, reason: {status_string}, id: {artifact_id_result}"

--- a/tests/test_email_data.py
+++ b/tests/test_email_data.py
@@ -677,6 +677,48 @@ def test_extract_urls_from_html_action_and_meta_refresh():
     assert "https://redirect.example/next" in urls
 
 
+def test_extract_email_body_aggregates_repeated_mime_parts():
+    """All inline parts of the same content type remain visible to analysis."""
+    mail = email.message_from_string(
+        """MIME-Version: 1.0
+Content-Type: multipart/mixed; boundary=BOUNDARY
+
+--BOUNDARY
+Content-Type: text/plain
+
+first plain part
+--BOUNDARY
+Content-Type: text/plain
+
+second plain part https://second.example/path
+--BOUNDARY
+Content-Type: text/html
+
+<p>first html part</p>
+--BOUNDARY
+Content-Type: text/html
+
+<a href="https://fourth.example/path">second html part</a>
+--BOUNDARY--
+"""
+    )
+
+    body = extract_email_body(mail)
+    urls = extract_email_urls(mail)
+
+    assert body.plain_text == (
+        "first plain part\nsecond plain part https://second.example/path"
+    )
+    assert body.html == (
+        '<p>first html part</p>\n<a href="https://fourth.example/path">'
+        "second html part</a>"
+    )
+    assert urls == [
+        "https://fourth.example/path",
+        "https://second.example/path",
+    ]
+
+
 def test_extract_urls_cleaned_non_http():
     """Test that non-http URLs after cleaning are filtered."""
     urls: set[str] = set()
@@ -754,7 +796,7 @@ Content-Type: text/html; charset="utf-8"
 
 
 def test_extract_body_duplicate_html_parts():
-    """Test multipart with multiple HTML parts - only first is used."""
+    """Test multipart with multiple HTML parts preserves all bodies."""
     email_content = """From: sender@example.com
 To: recipient@example.com
 Subject: Test
@@ -768,7 +810,7 @@ Content-Type: text/html; charset="utf-8"
 --boundary123
 Content-Type: text/html; charset="utf-8"
 
-<html><body>Second HTML - should be ignored</body></html>
+<html><body>Second HTML</body></html>
 --boundary123--
 """
     mail = email.message_from_string(email_content)
@@ -776,7 +818,32 @@ Content-Type: text/html; charset="utf-8"
 
     assert body.html is not None
     assert "First HTML" in body.html
-    assert "Second HTML" not in body.html
+    assert "Second HTML" in body.html
+
+
+def test_extract_body_ignores_inline_non_text_parts():
+    """Test inline non-text MIME parts are not treated as email bodies."""
+    email_content = """From: sender@example.com
+To: recipient@example.com
+Subject: Test
+MIME-Version: 1.0
+Content-Type: multipart/mixed; boundary="boundary123"
+
+--boundary123
+Content-Type: application/json
+
+{"ignored": true}
+--boundary123
+Content-Type: text/plain; charset="utf-8"
+
+Visible body
+--boundary123--
+"""
+    body = extract_email_body(email.message_from_string(email_content))
+
+    assert body.plain_text is not None
+    assert "Visible body" in body.plain_text
+    assert "ignored" not in body.plain_text
 
 
 def test_extract_msg_plaintext_only(msg_plaintext_only):

--- a/tests/test_email_processor.py
+++ b/tests/test_email_processor.py
@@ -952,6 +952,25 @@ Content-Type: text/html
     processor._del_tmp_dirs()
 
 
+def test_int_process_email_handles_parser_recursion_error(
+    mock_context: ProcessEmailContext, email_config: dict[str, bool]
+) -> None:
+    """Malformed recursive MIME input returns a per-message parsing error."""
+    processor = EmailProcessor(mock_context, email_config)
+
+    with patch(
+        "soar_sdk.extras.email.processor.email.message_from_string",
+        side_effect=RecursionError("maximum recursion depth exceeded"),
+    ):
+        ret_val, message, results = processor._int_process_email(
+            "malformed", "email-id", 1234567890.0
+        )
+
+    assert ret_val == 0
+    assert message == ("Failed to parse RFC822 email: maximum recursion depth exceeded")
+    assert results == []
+
+
 def test_handle_mail_object(
     mock_context: ProcessEmailContext, email_config: dict[str, bool]
 ) -> None:

--- a/tests/test_email_processor.py
+++ b/tests/test_email_processor.py
@@ -1,10 +1,11 @@
 import tempfile
 from email.message import Message
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, create_autospec, patch
 
 import pytest
 
+from soar_sdk.abstract import SOARClient
 from soar_sdk.extras.email import EmailProcessor, ProcessEmailContext
 from soar_sdk.extras.email.processor import validate_url
 from soar_sdk.extras.email.utils import (
@@ -1037,9 +1038,9 @@ def test_process_email(
     """Test process_email main entry point."""
     processor = EmailProcessor(mock_context, email_config)
 
-    mock_context.soar.save_container = MagicMock(return_value=123)
-    mock_context.soar.save_artifacts = MagicMock(return_value=[1, 2])
-    mock_context.soar.save_artifact = MagicMock(return_value=1)
+    mock_context.soar.container.create = MagicMock(return_value=123)
+    mock_context.soar.artifact.create = MagicMock(return_value=[1, 2])
+    mock_context.soar.artifact.create = MagicMock(return_value=1)
 
     rfc822_email = """From: sender@example.com
 To: recipient@example.com
@@ -1066,7 +1067,7 @@ def test_process_email_with_container_id(
     """Test process_email with existing container_id."""
     processor = EmailProcessor(mock_context, email_config)
 
-    mock_context.soar.save_artifacts = MagicMock(return_value=[1])
+    mock_context.soar.artifact.create = MagicMock(return_value=[1])
 
     rfc822_email = """From: sender@example.com
 Subject: Container Test
@@ -1092,7 +1093,7 @@ def test_process_email_with_headers(
     """Test process_email with external headers."""
     processor = EmailProcessor(mock_context, email_config)
 
-    mock_context.soar.save_container = MagicMock(return_value=123)
+    mock_context.soar.container.create = MagicMock(return_value=123)
 
     rfc822_email = """From: sender@example.com
 Subject: Headers Test
@@ -1121,7 +1122,7 @@ def test_process_email_with_attachments_data(
     """Test process_email with attachments data."""
     processor = EmailProcessor(mock_context, email_config)
 
-    mock_context.soar.save_container = MagicMock(return_value=123)
+    mock_context.soar.container.create = MagicMock(return_value=123)
 
     rfc822_email = """From: sender@example.com
 Subject: Attachments Test
@@ -1149,7 +1150,7 @@ def test_save_ingested_new_container(
     """Test _save_ingested creates new container."""
     processor = EmailProcessor(mock_context, email_config)
 
-    mock_context.soar.save_container = MagicMock(return_value=123)
+    mock_context.soar.container.create = MagicMock(return_value=123)
 
     container = {
         "name": "Test Container",
@@ -1162,13 +1163,40 @@ def test_save_ingested_new_container(
     assert cid == 123
 
 
+def test_save_ingested_uses_declared_soar_client_apis(
+    email_config: dict[str, bool],
+) -> None:
+    """A strict SOARClient mock rejects undeclared legacy save helpers."""
+    strict_soar = create_autospec(SOARClient, instance=True)
+    strict_soar.container.create.return_value = 123
+    context = ProcessEmailContext(
+        soar=strict_soar,
+        vault=MagicMock(),
+        app_id="test-app-id",
+        folder_name="INBOX",
+        is_hex=False,
+    )
+    processor = EmailProcessor(context, email_config)
+    container = {
+        "name": "Test Container",
+        "artifacts": [{"name": "Test Artifact", "cef": {}}],
+    }
+
+    ret_val, message, container_id = processor._save_ingested(
+        container, using_dummy=False
+    )
+
+    assert (ret_val, message, container_id) == (1, "Success", 123)
+    strict_soar.container.create.assert_called_once_with(container)
+
+
 def test_save_ingested_dummy_container(
     mock_context: ProcessEmailContext, email_config: dict[str, bool]
 ) -> None:
     """Test _save_ingested with dummy container."""
     processor = EmailProcessor(mock_context, email_config)
 
-    mock_context.soar.save_artifacts = MagicMock(return_value=[1, 2])
+    mock_context.soar.artifact.create = MagicMock(return_value=[1, 2])
 
     container = {
         "id": 999,
@@ -1187,7 +1215,7 @@ def test_save_ingested_error(
     """Test _save_ingested handles errors."""
     processor = EmailProcessor(mock_context, email_config)
 
-    mock_context.soar.save_container = MagicMock(side_effect=Exception("Save failed"))
+    mock_context.soar.container.create = MagicMock(side_effect=Exception("Save failed"))
 
     container = {"name": "Test", "artifacts": []}
 
@@ -1203,7 +1231,7 @@ def test_handle_save_ingested_with_container_id(
     """Test _handle_save_ingested with existing container_id."""
     processor = EmailProcessor(mock_context, email_config)
 
-    mock_context.soar.save_artifacts = MagicMock(return_value=[1])
+    mock_context.soar.artifact.create = MagicMock(return_value=[1])
 
     artifacts = [{"name": "Test", "cef": {"key": "value"}}]
 
@@ -1216,7 +1244,7 @@ def test_handle_save_ingested_with_container(
     """Test _handle_save_ingested with container object."""
     processor = EmailProcessor(mock_context, email_config)
 
-    mock_context.soar.save_container = MagicMock(return_value=123)
+    mock_context.soar.container.create = MagicMock(return_value=123)
 
     artifacts = [{"name": "Test", "cef": {}}]
     container = {"name": "Test Container"}
@@ -1306,7 +1334,7 @@ def test_handle_file(
     mock_context.vault.get_attachment = MagicMock(
         return_value=[{"metadata": {"sha256": "hash123"}}]
     )
-    mock_context.soar.save_artifact = MagicMock(return_value=1)
+    mock_context.soar.artifact.create = MagicMock(return_value=1)
 
     with tempfile.TemporaryDirectory() as tmp_dir:
         file_path = Path(tmp_dir) / "test.txt"
@@ -1337,7 +1365,7 @@ def test_handle_file_no_filename(
     mock_context.vault.get_attachment = MagicMock(
         return_value=[{"metadata": {"sha256": "hash"}}]
     )
-    mock_context.soar.save_artifact = MagicMock(return_value=1)
+    mock_context.soar.artifact.create = MagicMock(return_value=1)
 
     with tempfile.TemporaryDirectory() as tmp_dir:
         file_path = Path(tmp_dir) / "inferred.pdf"
@@ -1387,7 +1415,7 @@ def test_parse_results(
     """Test _parse_results processes email results."""
     processor = EmailProcessor(mock_context, email_config)
 
-    mock_context.soar.save_container = MagicMock(return_value=123)
+    mock_context.soar.container.create = MagicMock(return_value=123)
 
     with tempfile.TemporaryDirectory() as tmp_dir:
         results = [
@@ -1413,7 +1441,7 @@ def test_parse_results_with_container_id(
     """Test _parse_results with existing container_id."""
     processor = EmailProcessor(mock_context, email_config)
 
-    mock_context.soar.save_artifacts = MagicMock(return_value=[1])
+    mock_context.soar.artifact.create = MagicMock(return_value=[1])
 
     with tempfile.TemporaryDirectory() as tmp_dir:
         results = [
@@ -1437,7 +1465,7 @@ def test_parse_results_with_parent_guid(
     processor = EmailProcessor(mock_context, email_config)
     processor._guid_to_hash = {"parent-guid": "parent-hash-123"}
 
-    mock_context.soar.save_container = MagicMock(return_value=123)
+    mock_context.soar.container.create = MagicMock(return_value=123)
 
     with tempfile.TemporaryDirectory() as tmp_dir:
         results = [
@@ -1618,12 +1646,12 @@ def test_handle_save_ingested_with_files(
     """Test _handle_save_ingested with files."""
     processor = EmailProcessor(mock_context, email_config)
 
-    mock_context.soar.save_container = MagicMock(return_value=123)
+    mock_context.soar.container.create = MagicMock(return_value=123)
     mock_context.vault.add_attachment = MagicMock(return_value="vault-id")
     mock_context.vault.get_attachment = MagicMock(
         return_value=[{"metadata": {"sha256": "hash"}}]
     )
-    mock_context.soar.save_artifact = MagicMock(return_value=1)
+    mock_context.soar.artifact.create = MagicMock(return_value=1)
 
     artifacts = [{"name": "Test", "cef": {}}]
     container = {"name": "Test Container"}
@@ -1637,6 +1665,46 @@ def test_handle_save_ingested_with_files(
             mock_phantom.APP_JSON_ACTION_NAME = "action"
             mock_phantom.APP_JSON_APP_RUN_ID = "run_id"
             processor._handle_save_ingested(artifacts, container, None, files)
+
+
+def test_handle_save_ingested_propagates_file_failure(
+    mock_context: ProcessEmailContext, email_config: dict[str, bool]
+) -> None:
+    """Test a failed vault file save fails the complete ingestion."""
+    processor = EmailProcessor(mock_context, email_config)
+    container = {"name": "Test Container"}
+
+    with (
+        patch.object(processor, "_save_ingested", return_value=(1, "Success", 123)),
+        patch.object(processor, "_handle_file", return_value=(0, 0)),
+    ):
+        result = processor._handle_save_ingested(
+            [{"name": "Test", "cef": {}}],
+            container,
+            None,
+            [{"file_path": "/tmp/test.txt", "file_name": "test.txt"}],
+        )
+
+    assert result == 0
+
+
+def test_parse_results_propagates_save_failure(
+    mock_context: ProcessEmailContext, email_config: dict[str, bool]
+) -> None:
+    """Test a failed container save stops result parsing and is returned."""
+    processor = EmailProcessor(mock_context, email_config)
+    results = [
+        {
+            "container": {"name": "Test Container"},
+            "artifacts": [{"name": "Test", "cef": {}}],
+            "files": [],
+        }
+    ]
+
+    with patch.object(processor, "_handle_save_ingested", return_value=0):
+        status = processor._parse_results(results)
+
+    assert status == 0
 
 
 def test_process_email_failure(
@@ -1657,6 +1725,32 @@ def test_process_email_failure(
         )
 
     assert ret_val == 0
+
+
+def test_process_email_reports_save_failure(
+    mock_context: ProcessEmailContext, email_config: dict[str, bool]
+) -> None:
+    """Test process_email propagates a failed container or artifact save."""
+    processor = EmailProcessor(mock_context, email_config)
+
+    with (
+        patch.object(
+            processor,
+            "_int_process_email",
+            return_value=(1, "Email Parsed", [{"artifacts": [{}]}]),
+        ),
+        patch.object(processor, "_parse_results", return_value=0),
+    ):
+        ret_val, message = processor.process_email(
+            base_connector=MagicMock(),
+            rfc822_email="From: sender@example.com\n\nBody",
+            email_id="test",
+            config=email_config,
+            epoch=1234567890.0,
+        )
+
+    assert ret_val == 0
+    assert message == "Failed to save processed email data"
 
 
 def test_handle_part_rfc822(
@@ -1738,12 +1832,12 @@ def test_handle_save_ingested_error(
     """Test _handle_save_ingested handles save errors."""
     processor = EmailProcessor(mock_context, email_config)
 
-    mock_context.soar.save_container = MagicMock(side_effect=Exception("Save error"))
+    mock_context.soar.container.create = MagicMock(side_effect=Exception("Save error"))
 
     artifacts = [{"name": "Test", "cef": {}}]
     container = {"name": "Test Container"}
 
-    processor._handle_save_ingested(artifacts, container, None, [])
+    assert processor._handle_save_ingested(artifacts, container, None, []) == 0
 
 
 def test_handle_attachment_long_filename(
@@ -1810,7 +1904,7 @@ def test_handle_file_with_parent_guid(
     mock_context.vault.get_attachment = MagicMock(
         return_value=[{"metadata": {"sha256": "hash"}}]
     )
-    mock_context.soar.save_artifact = MagicMock(return_value=1)
+    mock_context.soar.artifact.create = MagicMock(return_value=1)
 
     with tempfile.TemporaryDirectory() as tmp_dir:
         file_path = Path(tmp_dir) / "test.txt"
@@ -1840,7 +1934,7 @@ def test_handle_file_no_vault_id(
     processor = EmailProcessor(mock_context, email_config)
 
     mock_context.vault.add_attachment = MagicMock(return_value=None)
-    mock_context.soar.save_artifact = MagicMock(return_value=1)
+    mock_context.soar.artifact.create = MagicMock(return_value=1)
 
     with tempfile.TemporaryDirectory() as tmp_dir:
         file_path = Path(tmp_dir) / "test.txt"
@@ -1865,7 +1959,7 @@ def test_save_ingested_dummy_error(
     """Test _save_ingested with dummy container error."""
     processor = EmailProcessor(mock_context, email_config)
 
-    mock_context.soar.save_artifacts = MagicMock(
+    mock_context.soar.artifact.create = MagicMock(
         side_effect=Exception("Artifact error")
     )
 
@@ -2015,12 +2109,12 @@ def test_parse_results_with_files(
     """Test _parse_results processes files."""
     processor = EmailProcessor(mock_context, email_config)
 
-    mock_context.soar.save_container = MagicMock(return_value=123)
+    mock_context.soar.container.create = MagicMock(return_value=123)
     mock_context.vault.add_attachment = MagicMock(return_value="vault-id")
     mock_context.vault.get_attachment = MagicMock(
         return_value=[{"metadata": {"sha256": "hash123"}}]
     )
-    mock_context.soar.save_artifact = MagicMock(return_value=1)
+    mock_context.soar.artifact.create = MagicMock(return_value=1)
 
     with tempfile.TemporaryDirectory() as tmp_dir:
         file_path = Path(tmp_dir) / "attach.txt"
@@ -2650,7 +2744,7 @@ def test_handle_save_ingested_container_id_none(
     """Test _handle_save_ingested when save returns no container_id."""
     processor = EmailProcessor(mock_context, email_config)
 
-    mock_context.soar.save_container = MagicMock(return_value=None)
+    mock_context.soar.container.create = MagicMock(return_value=None)
 
     artifacts = [{"name": "Test", "cef": {}}]
     container = {"name": "Test Container"}
@@ -2676,12 +2770,12 @@ def test_handle_save_ingested_with_vault_file(
     """Test _handle_save_ingested processes vault files."""
     processor = EmailProcessor(mock_context, email_config)
 
-    mock_context.soar.save_container = MagicMock(return_value=123)
+    mock_context.soar.container.create = MagicMock(return_value=123)
     mock_context.vault.add_attachment = MagicMock(return_value="vault-id")
     mock_context.vault.get_attachment = MagicMock(
         return_value=[{"metadata": {"sha256": "hash"}}]
     )
-    mock_context.soar.save_artifact = MagicMock(return_value=1)
+    mock_context.soar.artifact.create = MagicMock(return_value=1)
 
     artifacts = [{"name": "Test", "cef": {}}]
     container = {"name": "Test"}
@@ -2707,7 +2801,7 @@ def test_handle_file_added_to_vault(
     mock_context.vault.get_attachment = MagicMock(
         return_value=[{"metadata": {"sha256": "hash"}}]
     )
-    mock_context.soar.save_artifact = MagicMock(return_value=1)
+    mock_context.soar.artifact.create = MagicMock(return_value=1)
 
     with tempfile.TemporaryDirectory() as tmp_dir:
         file_path = Path(tmp_dir) / "test.txt"
@@ -3306,7 +3400,7 @@ def test_handle_save_ingested_file_not_added(
     """Test _handle_save_ingested when file not added to vault."""
     processor = EmailProcessor(mock_context, email_config)
 
-    mock_context.soar.save_container = MagicMock(return_value=123)
+    mock_context.soar.container.create = MagicMock(return_value=123)
 
     with patch.object(processor, "_handle_file", return_value=(1, False)):
         artifacts = [{"name": "Test", "cef": {}}]
@@ -3343,9 +3437,9 @@ def test_parse_results_empty_artifact_in_list(
     """Test _parse_results handles None artifact in list."""
     processor = EmailProcessor(mock_context, email_config)
 
-    mock_context.soar.save_container = MagicMock(return_value=123)
-    mock_context.soar.save_artifacts = MagicMock(return_value=[1])
-    mock_context.soar.save_artifact = MagicMock(return_value=1)
+    mock_context.soar.container.create = MagicMock(return_value=123)
+    mock_context.soar.artifact.create = MagicMock(return_value=[1])
+    mock_context.soar.artifact.create = MagicMock(return_value=1)
 
     with tempfile.TemporaryDirectory() as tmp_dir:
         results = [
@@ -3614,7 +3708,7 @@ def test_parse_results_parent_guid_in_artifact(
     processor = EmailProcessor(mock_context, email_config)
     processor._guid_to_hash = {"parent-guid": "parent-hash"}
 
-    mock_context.soar.save_container = MagicMock(return_value=123)
+    mock_context.soar.container.create = MagicMock(return_value=123)
 
     with tempfile.TemporaryDirectory() as tmp_dir:
         results = [
@@ -3640,7 +3734,7 @@ def test_parse_results_email_guid_in_artifact(
     """Test _parse_results with emailGuid in artifact cef."""
     processor = EmailProcessor(mock_context, email_config)
 
-    mock_context.soar.save_container = MagicMock(return_value=123)
+    mock_context.soar.container.create = MagicMock(return_value=123)
 
     with tempfile.TemporaryDirectory() as tmp_dir:
         results = [
@@ -3726,7 +3820,7 @@ def test_handle_file_with_contains(
     mock_context.vault.get_attachment = MagicMock(
         return_value=[{"metadata": {"sha256": "hash"}}]
     )
-    mock_context.soar.save_artifact = MagicMock(return_value=1)
+    mock_context.soar.artifact.create = MagicMock(return_value=1)
 
     with tempfile.TemporaryDirectory() as tmp_dir:
         file_path = Path(tmp_dir) / "test.txt"
@@ -3755,7 +3849,7 @@ def test_handle_file_save_artifact_exception(
     mock_context.vault.get_attachment = MagicMock(
         return_value=[{"metadata": {"sha256": "hash"}}]
     )
-    mock_context.soar.save_artifact = MagicMock(side_effect=Exception("Save error"))
+    mock_context.soar.artifact.create = MagicMock(side_effect=Exception("Save error"))
 
     with tempfile.TemporaryDirectory() as tmp_dir:
         file_path = Path(tmp_dir) / "test.txt"
@@ -3784,7 +3878,7 @@ def test_handle_file_with_filename_only(
     mock_context.vault.get_attachment = MagicMock(
         return_value=[{"metadata": {"sha256": "hash"}}]
     )
-    mock_context.soar.save_artifact = MagicMock(return_value=1)
+    mock_context.soar.artifact.create = MagicMock(return_value=1)
 
     with tempfile.TemporaryDirectory() as tmp_dir:
         file_path = Path(tmp_dir) / "test.txt"
@@ -3860,7 +3954,7 @@ def test_handle_file_with_file_contains(
     mock_context.vault.get_attachment = MagicMock(
         return_value=[{"metadata": {"sha256": "hash"}}]
     )
-    mock_context.soar.save_artifact = MagicMock(return_value=1)
+    mock_context.soar.artifact.create = MagicMock(return_value=1)
 
     with tempfile.TemporaryDirectory() as tmp_dir:
         file_path = Path(tmp_dir) / "test.pdf"
@@ -3889,7 +3983,7 @@ def test_parse_results_parent_guid_not_in_hash(
     processor = EmailProcessor(mock_context, email_config)
     processor._guid_to_hash = {}
 
-    mock_context.soar.save_container = MagicMock(return_value=123)
+    mock_context.soar.container.create = MagicMock(return_value=123)
 
     with tempfile.TemporaryDirectory() as tmp_dir:
         results = [
@@ -4046,7 +4140,7 @@ def test_parse_results_temp_directory_cleanup(
     """Test _parse_results cleans up temp directories."""
     processor = EmailProcessor(mock_context, email_config)
 
-    mock_context.soar.save_container = MagicMock(return_value=123)
+    mock_context.soar.container.create = MagicMock(return_value=123)
 
     tmp_dir = tempfile.mkdtemp()
     Path(tmp_dir).mkdir(parents=True, exist_ok=True)
@@ -4763,7 +4857,7 @@ def test_parse_results_no_result_temp_directory(
     """Test _parse_results when temp_directory is not in result."""
     processor = EmailProcessor(mock_context, email_config)
 
-    mock_context.soar.save_container = MagicMock(return_value=123)
+    mock_context.soar.container.create = MagicMock(return_value=123)
 
     results = [
         {

--- a/tests/test_email_processor.py
+++ b/tests/test_email_processor.py
@@ -1039,7 +1039,6 @@ def test_process_email(
     processor = EmailProcessor(mock_context, email_config)
 
     mock_context.soar.container.create = MagicMock(return_value=123)
-    mock_context.soar.artifact.create = MagicMock(return_value=[1, 2])
     mock_context.soar.artifact.create = MagicMock(return_value=1)
 
     rfc822_email = """From: sender@example.com
@@ -3865,7 +3864,8 @@ def test_handle_file_save_artifact_exception(
             mock_phantom.APP_JSON_APP_RUN_ID = "run_id"
             ret_val, added = processor._handle_file(curr_file, [], 123, 0)
 
-    assert ret_val == 1
+    assert ret_val == 0
+    assert added == 0
 
 
 def test_handle_file_with_filename_only(


### PR DESCRIPTION
## Summary

- return controlled failures for recursive or malformed email parsing
- aggregate repeated plain-text and HTML MIME body parts
- replace undeclared legacy save helpers with the supported `SOARClient` container and artifact APIs, propagating save failures

This is a shared platform fix so connectors consuming the SDK receive the behavior without duplicating local implementations.

The Unicode/IDN URL extraction work previously included on this branch was delivered separately in [PR #226](https://github.com/phantomcyber/splunk-soar-sdk/pull/226) and has been removed from this PR.

## Tracking

- Parent epic: [ESPM-5228](https://splunk.atlassian.net/browse/ESPM-5228)
- PAPP: [PAPP-38057](https://splunk.atlassian.net/browse/PAPP-38057)
- Outstanding findings: [PSAAS-31895](https://splunk.atlassian.net/browse/PSAAS-31895), [PSAAS-32127](https://splunk.atlassian.net/browse/PSAAS-32127), [PSAAS-32256](https://splunk.atlassian.net/browse/PSAAS-32256)
- Already delivered by PR #226: [PSAAS-31919](https://splunk.atlassian.net/browse/PSAAS-31919)

## Quality gate

- `pre-commit run --all-files`
- `uv run python -m compileall -q src tests`
- `uv run pytest -q` — 1,309 passed, 17 skipped, 100% coverage

Prepared entirely with AI assistance by Codex.
