### PR TITLE
fix: exclude malformed Authlib 1.7.2 release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ dependencies = [
     "httpx-retries>=0.4.5",
     "hatchling>=1.28.0",
     # OAuth 2.0 support
-    "authlib>=1.3.0",
+    "authlib>=1.3.0,!=1.7.2",
     "pyjwt[crypto]>=2.8.0",
     "extract-msg>=0.55.0",
     # License attribution

--- a/uv.lock
+++ b/uv.lock
@@ -1522,7 +1522,7 @@ docs = [
 
 [package.metadata]
 requires-dist = [
-    { name = "authlib", specifier = ">=1.3.0" },
+    { name = "authlib", specifier = ">=1.3.0,!=1.7.2" },
     { name = "beautifulsoup4", specifier = ">=4.10.0" },
     { name = "bleach", specifier = ">=6.2.0" },
     { name = "build", specifier = ">=1.3.0" },


### PR DESCRIPTION
## Summary\n\n- exclude Authlib 1.7.2, whose published wheel contains a Python syntax error\n- retain support for newer compatible Authlib releases\n- prevent SDK consumers such as Microsoft OneDrive from failing during imports and static validation\n\n## Validation\n\n- pre-commit run --all-files\n- 172 focused OAuth tests passed\n\n## References\n\n- Microsoft OneDrive PSAAS-31388\n- Microsoft OneDrive PSAAS-32177\n\nCreated by Codex with AI assistance.