### PR TITLE
ci: configure Dependabot security updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+version: 2
+
+updates:
+  - package-ecosystem: "uv"
+    directories:
+      - "/"
+      - "/mcp_server"
+      - "/tests/example_app"
+      - "/tests/example_app_plaintext_state"
+      - "/tests/example_app_with_oauth"
+      - "/tests/example_app_with_webhook"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 0
+    commit-message:
+      prefix: "fix"
+      include: "scope"


### PR DESCRIPTION
## Summary

- configure Dependabot for every uv project in the repository
- limit Dependabot to security updates by disabling routine version-update PRs
- format generated commits as `fix(deps): ...` so merged security updates trigger semantic-release patch releases

## Why

The repository did not have a Dependabot configuration for uv dependencies. This adds consistent security-update PR behavior across the root package, MCP server, and example applications.

## Impact

Once **Dependabot security updates** is enabled in the repository's Advanced Security settings, GitHub can automatically open remediation PRs for vulnerable uv dependencies. Routine non-security version updates remain disabled.

## Validation

- parsed `.github/dependabot.yml` as YAML and asserted the expected settings
- `git diff --check`
- repository pre-commit hooks, including YAML validation and commitlint
