### PR TITLE
feat: support complete action lock metadata

### DIFF
--- a/docs/app_structure/src_app.rst
+++ b/docs/app_structure/src_app.rst
@@ -264,7 +264,6 @@ overlapping executions for every asset that points to the same server:
 
     @app.action(
         lock=ActionLock(
-            concurrency=False,
             data_path="configuration.server",
             timeout=600,
         )
@@ -276,16 +275,23 @@ overlapping executions for every asset that points to the same server:
     ) -> UpdateConfigurationOutput:
         ...
 
-``concurrency=False`` restricts the lock to one action run at a time.
+An ``ActionLock`` is always enabled and exclusive. The SDK emits
+``enabled=true`` and ``concurrency=false`` in the app manifest, restricting
+each resolved lock name to one action run at a time.
 ``data_path`` may identify an action parameter, an asset configuration field,
 or a constant lock name. Actions that resolve to the same lock name are
 serialized. If ``data_path`` is omitted, Splunk SOAR uses the asset as the lock
 name. ``timeout`` limits how long the platform waits to acquire the lock.
 
 The older ``enable_concurrency_lock=True`` argument is deprecated but remains
-supported for backward compatibility. Use ``lock=ActionLock()`` for equivalent
-behavior and configure concurrency, a lock name, or a timeout through
-``ActionLock``.
+supported for backward compatibility. Remove the argument to retain the
+platform's default concurrency behavior. Use ``lock=ActionLock()`` only when
+exclusive action locking is required.
+
+.. note::
+    ``soar-apps convert`` does not translate existing manifest ``lock``
+    metadata. Review synchronization requirements and add ``ActionLock``
+    explicitly after conversion when exclusive locking is required.
 
 .. _app-structure-app-cli:
 

--- a/docs/app_structure/src_app.rst
+++ b/docs/app_structure/src_app.rst
@@ -282,9 +282,10 @@ or a constant lock name. Actions that resolve to the same lock name are
 serialized. If ``data_path`` is omitted, Splunk SOAR uses the asset as the lock
 name. ``timeout`` limits how long the platform waits to acquire the lock.
 
-The older ``enable_concurrency_lock=True`` argument remains supported for
-backward compatibility, but it cannot configure concurrency, a lock name, or a
-timeout. New actions should use ``ActionLock``.
+The older ``enable_concurrency_lock=True`` argument is deprecated but remains
+supported for backward compatibility. Use ``lock=ActionLock()`` for equivalent
+behavior and configure concurrency, a lock name, or a timeout through
+``ActionLock``.
 
 .. _app-structure-app-cli:
 

--- a/docs/app_structure/src_app.rst
+++ b/docs/app_structure/src_app.rst
@@ -250,6 +250,42 @@ Actions can be registered one of two ways:
 
 The two methods are functionally equivalent. The decorator method is often more convenient for simple actions, while the registration method may be preferable for larger apps where actions are defined in separate modules. Apps may use either or both methods to register their actions.
 
+Action Synchronization
+^^^^^^^^^^^^^^^^^^^^^^
+
+Use :class:`~soar_sdk.meta.actions.ActionLock` when an action must coordinate
+with other action runs. For example, a read-modify-write operation can prevent
+overlapping executions for every asset that points to the same server:
+
+.. code-block:: python
+
+    from soar_sdk.meta.actions import ActionLock
+
+
+    @app.action(
+        lock=ActionLock(
+            concurrency=False,
+            data_path="configuration.server",
+            timeout=600,
+        )
+    )
+    def update_configuration(
+        params: UpdateConfigurationParams,
+        soar: SOARClient,
+        asset: Asset,
+    ) -> UpdateConfigurationOutput:
+        ...
+
+``concurrency=False`` restricts the lock to one action run at a time.
+``data_path`` may identify an action parameter, an asset configuration field,
+or a constant lock name. Actions that resolve to the same lock name are
+serialized. If ``data_path`` is omitted, Splunk SOAR uses the asset as the lock
+name. ``timeout`` limits how long the platform waits to acquire the lock.
+
+The older ``enable_concurrency_lock=True`` argument remains supported for
+backward compatibility, but it cannot configure concurrency, a lock name, or a
+timeout. New actions should use ``ActionLock``.
+
 .. _app-structure-app-cli:
 
 App CLI Invocation

--- a/src/soar_sdk/app.py
+++ b/src/soar_sdk/app.py
@@ -356,8 +356,8 @@ class App:
             lock: Optional synchronization metadata for controlling action locks,
                 concurrency, lock names, and acquisition timeouts.
             enable_concurrency_lock: Whether to enable a concurrency lock for this action. Defaults to False.
-                This argument is retained for backward compatibility; use ``lock``
-                for new actions.
+                This argument is deprecated and retained for backward compatibility;
+                use ``lock=ActionLock()`` instead.
 
         Returns:
             The registered Action instance with all metadata and handlers configured.

--- a/src/soar_sdk/app.py
+++ b/src/soar_sdk/app.py
@@ -32,6 +32,7 @@ from soar_sdk.decorators import (
 from soar_sdk.exceptions import ActionRegistrationError
 from soar_sdk.input_spec import InputSpecification
 from soar_sdk.logging import getLogger
+from soar_sdk.meta.actions import ActionLock
 from soar_sdk.meta.webhooks import WebhookMeta
 from soar_sdk.params import Params
 from soar_sdk.shims.phantom_common.app_interface.app_interface import SoarRestClient
@@ -290,6 +291,7 @@ class App:
         view_template: str | None = None,
         versions: str = "EQ(*)",
         summary_type: type[ActionOutput] | None = None,
+        lock: ActionLock | None = None,
         enable_concurrency_lock: bool = False,
     ) -> Action:
         """Dynamically register an action function defined in another module.
@@ -351,7 +353,11 @@ class App:
             versions: Version constraint string for when this action is available.
                 Defaults to "EQ(*)" (all versions).
             summary_type: Pydantic model class for structuring action summary output.
+            lock: Optional synchronization metadata for controlling action locks,
+                concurrency, lock names, and acquisition timeouts.
             enable_concurrency_lock: Whether to enable a concurrency lock for this action. Defaults to False.
+                This argument is retained for backward compatibility; use ``lock``
+                for new actions.
 
         Returns:
             The registered Action instance with all metadata and handlers configured.
@@ -408,6 +414,7 @@ class App:
             view_handler=view_handler,
             versions=versions,
             summary_type=summary_type,
+            lock=lock,
             enable_concurrency_lock=enable_concurrency_lock,
         )(action)
 
@@ -475,6 +482,7 @@ class App:
         view_handler: NamedCallable | None = None,
         versions: str = "EQ(*)",
         summary_type: type[ActionOutput] | None = None,
+        lock: ActionLock | None = None,
         enable_concurrency_lock: bool = False,
         flatten_results: bool = True,
     ) -> ActionDecorator:
@@ -496,6 +504,7 @@ class App:
             view_handler=view_handler,
             versions=versions,
             summary_type=summary_type,
+            lock=lock,
             enable_concurrency_lock=enable_concurrency_lock,
             flatten_results=flatten_results,
         )

--- a/src/soar_sdk/app.py
+++ b/src/soar_sdk/app.py
@@ -357,7 +357,8 @@ class App:
                 concurrency, lock names, and acquisition timeouts.
             enable_concurrency_lock: Whether to enable a concurrency lock for this action. Defaults to False.
                 This argument is deprecated and retained for backward compatibility;
-                use ``lock=ActionLock()`` instead.
+                remove it to retain the platform's default concurrency behavior. Use
+                ``lock=ActionLock()`` only when exclusive action locking is required.
 
         Returns:
             The registered Action instance with all metadata and handlers configured.

--- a/src/soar_sdk/cli/manifests/deserializers.py
+++ b/src/soar_sdk/cli/manifests/deserializers.py
@@ -131,6 +131,8 @@ class ActionDeserializer:
             A DeserializedActionMeta named tuple containing the ActionMeta and
             info about whether the action has a custom view.
         """
+        action.pop("lock", None)
+
         action["parameters"] = cls.parse_parameters(
             action["action"], action.get("parameters", {})
         )

--- a/src/soar_sdk/code_renderers/action_renderer.py
+++ b/src/soar_sdk/code_renderers/action_renderer.py
@@ -241,6 +241,45 @@ class ActionRenderer(AstRenderer[ActionMeta]):
                     ),
                 )
             )
+        if self.action_meta.lock is not None:
+            lock_keywords = []
+            if not self.action_meta.lock.enabled:
+                lock_keywords.append(
+                    ast.keyword(arg="enabled", value=ast.Constant(value=False))
+                )
+            if self.action_meta.lock.concurrency is not None:
+                lock_keywords.append(
+                    ast.keyword(
+                        arg="concurrency",
+                        value=ast.Constant(
+                            value=self.action_meta.lock.concurrency,
+                        ),
+                    )
+                )
+            if self.action_meta.lock.data_path is not None:
+                lock_keywords.append(
+                    ast.keyword(
+                        arg="data_path",
+                        value=ast.Constant(value=self.action_meta.lock.data_path),
+                    )
+                )
+            if self.action_meta.lock.timeout is not None:
+                lock_keywords.append(
+                    ast.keyword(
+                        arg="timeout",
+                        value=ast.Constant(value=self.action_meta.lock.timeout),
+                    )
+                )
+            decorator_keywords.append(
+                ast.keyword(
+                    arg="lock",
+                    value=ast.Call(
+                        func=ast.Name(id="ActionLock", ctx=ast.Load()),
+                        args=[],
+                        keywords=lock_keywords,
+                    ),
+                )
+            )
 
         node = ast.FunctionDef(
             name=self.action_meta.identifier,

--- a/src/soar_sdk/code_renderers/action_renderer.py
+++ b/src/soar_sdk/code_renderers/action_renderer.py
@@ -243,19 +243,6 @@ class ActionRenderer(AstRenderer[ActionMeta]):
             )
         if lock := self.action_meta.lock:
             lock_keywords = []
-            if not lock.enabled:
-                lock_keywords.append(
-                    ast.keyword(arg="enabled", value=ast.Constant(value=False))
-                )
-            if lock.concurrency is not None:
-                lock_keywords.append(
-                    ast.keyword(
-                        arg="concurrency",
-                        value=ast.Constant(
-                            value=lock.concurrency,
-                        ),
-                    )
-                )
             if lock.data_path is not None:
                 lock_keywords.append(
                     ast.keyword(

--- a/src/soar_sdk/code_renderers/action_renderer.py
+++ b/src/soar_sdk/code_renderers/action_renderer.py
@@ -241,33 +241,33 @@ class ActionRenderer(AstRenderer[ActionMeta]):
                     ),
                 )
             )
-        if self.action_meta.lock is not None:
+        if lock := self.action_meta.lock:
             lock_keywords = []
-            if not self.action_meta.lock.enabled:
+            if not lock.enabled:
                 lock_keywords.append(
                     ast.keyword(arg="enabled", value=ast.Constant(value=False))
                 )
-            if self.action_meta.lock.concurrency is not None:
+            if lock.concurrency is not None:
                 lock_keywords.append(
                     ast.keyword(
                         arg="concurrency",
                         value=ast.Constant(
-                            value=self.action_meta.lock.concurrency,
+                            value=lock.concurrency,
                         ),
                     )
                 )
-            if self.action_meta.lock.data_path is not None:
+            if lock.data_path is not None:
                 lock_keywords.append(
                     ast.keyword(
                         arg="data_path",
-                        value=ast.Constant(value=self.action_meta.lock.data_path),
+                        value=ast.Constant(value=lock.data_path),
                     )
                 )
-            if self.action_meta.lock.timeout is not None:
+            if lock.timeout is not None:
                 lock_keywords.append(
                     ast.keyword(
                         arg="timeout",
-                        value=ast.Constant(value=self.action_meta.lock.timeout),
+                        value=ast.Constant(value=lock.timeout),
                     )
                 )
             decorator_keywords.append(

--- a/src/soar_sdk/code_renderers/app_renderer.py
+++ b/src/soar_sdk/code_renderers/app_renderer.py
@@ -50,8 +50,7 @@ class AppRenderer:
         """
         self.context = context
 
-    @staticmethod
-    def create_default_imports() -> Iterator[ast.Import | ast.ImportFrom]:
+    def create_default_imports(self) -> Iterator[ast.Import | ast.ImportFrom]:
         """Create default imports for the App module.
 
         Returns:
@@ -76,6 +75,16 @@ class AppRenderer:
         yield ast.ImportFrom(
             module="soar_sdk.app", names=[ast.alias(name="App", asname=None)], level=0
         )
+        if any(
+            isinstance(node, ast.Name) and node.id == "ActionLock"
+            for content in self.context.app_content
+            for node in ast.walk(content)
+        ):
+            yield ast.ImportFrom(
+                module="soar_sdk.meta.actions",
+                names=[ast.alias(name="ActionLock", asname=None)],
+                level=0,
+            )
         yield ast.ImportFrom(
             module="soar_sdk.params",
             names=[

--- a/src/soar_sdk/decorators/action.py
+++ b/src/soar_sdk/decorators/action.py
@@ -8,7 +8,7 @@ from soar_sdk.abstract import SOARClient
 from soar_sdk.action_results import ActionOutput, ActionResult
 from soar_sdk.async_utils import run_async_if_needed
 from soar_sdk.exceptions import ActionFailure
-from soar_sdk.meta.actions import ActionMeta
+from soar_sdk.meta.actions import ActionLock, ActionMeta
 from soar_sdk.params import Params
 from soar_sdk.types import Action, NamedCallable, action_protocol
 
@@ -38,6 +38,7 @@ class ActionDecorator:
         view_handler: NamedCallable | None = None,
         versions: str = "EQ(*)",
         summary_type: type[ActionOutput] | None = None,
+        lock: ActionLock | None = None,
         enable_concurrency_lock: bool = False,
         flatten_results: bool = True,
     ) -> None:
@@ -54,6 +55,7 @@ class ActionDecorator:
         self.view_handler = view_handler
         self.versions = versions
         self.summary_type = summary_type
+        self.lock = lock
         self.enable_concurrency_lock = enable_concurrency_lock
         self.flatten_results = flatten_results
 
@@ -164,6 +166,7 @@ class ActionDecorator:
             render_as=self.render_as,
             view_handler=self.view_handler,
             summary_type=self.summary_type,
+            lock=self.lock,
             enable_concurrency_lock=self.enable_concurrency_lock,
         )
 

--- a/src/soar_sdk/meta/actions.py
+++ b/src/soar_sdk/meta/actions.py
@@ -1,3 +1,4 @@
+import warnings
 from typing import Any, Type  # noqa: UP035
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
@@ -45,6 +46,11 @@ class ActionMeta(BaseModel):
                 raise ValueError(
                     "lock and enable_concurrency_lock cannot both be configured"
                 )
+            warnings.warn(
+                "enable_concurrency_lock is deprecated; use lock=ActionLock() instead",
+                DeprecationWarning,
+                stacklevel=2,
+            )
             self.lock = ActionLock()
             self.enable_concurrency_lock = False
         return self

--- a/src/soar_sdk/meta/actions.py
+++ b/src/soar_sdk/meta/actions.py
@@ -14,8 +14,8 @@ class ActionLock(BaseModel):
 
     enabled: bool = True
     concurrency: bool | None = None
-    data_path: str | None = None
-    timeout: int | None = Field(default=None, gt=0)
+    data_path: str | None = Field(default=None, min_length=1)
+    timeout: int | None = Field(default=None, ge=0)
 
 
 class ActionMeta(BaseModel):

--- a/src/soar_sdk/meta/actions.py
+++ b/src/soar_sdk/meta/actions.py
@@ -1,11 +1,20 @@
 from typing import Any, Type  # noqa: UP035
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from soar_sdk.action_results import ActionOutput
 from soar_sdk.cli.manifests.serializers import OutputsSerializer, ParamsSerializer
 from soar_sdk.params import Params
 from soar_sdk.types import NamedCallable
+
+
+class ActionLock(BaseModel):
+    """Synchronization metadata for an action."""
+
+    enabled: bool = True
+    concurrency: bool | None = None
+    data_path: str | None = None
+    timeout: int | None = Field(default=None, gt=0)
 
 
 class ActionMeta(BaseModel):
@@ -25,11 +34,25 @@ class ActionMeta(BaseModel):
     render_as: str | None = None
     view_handler: NamedCallable | None = None
     summary_type: Type[ActionOutput] | None = Field(default=None, exclude=True)  # noqa: UP006
-    enable_concurrency_lock: bool = False
+    lock: ActionLock | None = None
+    enable_concurrency_lock: bool = Field(default=False, exclude=True)
+
+    @model_validator(mode="after")
+    def normalize_legacy_concurrency_lock(self) -> "ActionMeta":
+        """Translate the legacy lock flag while rejecting ambiguous configuration."""
+        if getattr(self, "enable_concurrency_lock", False):
+            if getattr(self, "lock", None) is not None:
+                raise ValueError(
+                    "lock and enable_concurrency_lock cannot both be configured"
+                )
+            self.lock = ActionLock()
+            self.enable_concurrency_lock = False
+        return self
 
     def model_dump(self, *args: Any, **kwargs: Any) -> dict[str, Any]:  # noqa: ANN401
         """Serializes the action metadata to a dictionary."""
         data = super().model_dump(*args, **kwargs)
+        data.pop("lock", None)
         data["parameters"] = ParamsSerializer.serialize_fields_info(self.parameters)
         data["output"] = OutputsSerializer.serialize_datapaths(
             self.parameters, self.output, summary_class=self.summary_type
@@ -55,8 +78,7 @@ class ActionMeta(BaseModel):
         data.pop("view_handler", None)
         data.pop("render_as", None)
 
-        if self.enable_concurrency_lock:
-            data["lock"] = {"enabled": True}
-        data.pop("enable_concurrency_lock", None)
+        if self.lock is not None:
+            data["lock"] = self.lock.model_dump(exclude_none=True)
 
         return data

--- a/src/soar_sdk/meta/actions.py
+++ b/src/soar_sdk/meta/actions.py
@@ -40,19 +40,20 @@ class ActionMeta(BaseModel):
 
     @model_validator(mode="after")
     def normalize_legacy_concurrency_lock(self) -> "ActionMeta":
-        """Translate the legacy lock flag while rejecting ambiguous configuration."""
+        """Warn for the legacy lock flag while rejecting ambiguous configuration."""
         if getattr(self, "enable_concurrency_lock", False):
             if getattr(self, "lock", None) is not None:
                 raise ValueError(
                     "lock and enable_concurrency_lock cannot both be configured"
                 )
             warnings.warn(
-                "enable_concurrency_lock is deprecated; use lock=ActionLock() instead",
+                "enable_concurrency_lock is deprecated and will be removed in a "
+                "future major release. Remove this argument to retain the platform's "
+                "default concurrency behavior. Use lock=ActionLock(...) only when "
+                "exclusive action locking is required.",
                 DeprecationWarning,
                 stacklevel=2,
             )
-            self.lock = ActionLock()
-            self.enable_concurrency_lock = False
         return self
 
     def model_dump(self, *args: Any, **kwargs: Any) -> dict[str, Any]:  # noqa: ANN401
@@ -90,5 +91,7 @@ class ActionMeta(BaseModel):
                 "concurrency": False,
                 **self.lock.model_dump(exclude_none=True),
             }
+        elif self.enable_concurrency_lock:
+            data["lock"] = {"enabled": True}
 
         return data

--- a/src/soar_sdk/meta/actions.py
+++ b/src/soar_sdk/meta/actions.py
@@ -12,8 +12,8 @@ from soar_sdk.types import NamedCallable
 class ActionLock(BaseModel):
     """Synchronization metadata for an action."""
 
-    enabled: bool = True
-    concurrency: bool | None = None
+    model_config = ConfigDict(extra="forbid")
+
     data_path: str | None = Field(default=None, min_length=1)
     timeout: int | None = Field(default=None, ge=0)
 
@@ -85,6 +85,10 @@ class ActionMeta(BaseModel):
         data.pop("render_as", None)
 
         if self.lock is not None:
-            data["lock"] = self.lock.model_dump(exclude_none=True)
+            data["lock"] = {
+                "enabled": True,
+                "concurrency": False,
+                **self.lock.model_dump(exclude_none=True),
+            }
 
         return data

--- a/tests/cli/test_deserializers.py
+++ b/tests/cli/test_deserializers.py
@@ -1,3 +1,4 @@
+import ast
 import json
 from unittest.mock import Mock, patch
 
@@ -10,8 +11,9 @@ from soar_sdk.cli.manifests.deserializers import (
     DeserializedActionMeta,
 )
 from soar_sdk.cli.manifests.serializers import OutputsSerializer
+from soar_sdk.code_renderers.action_renderer import ActionRenderer
 from soar_sdk.compat import PythonVersion
-from soar_sdk.meta.actions import ActionMeta
+from soar_sdk.meta.actions import ActionLock, ActionMeta
 from soar_sdk.meta.app import AppMeta
 from soar_sdk.params import Params
 
@@ -96,6 +98,44 @@ def test_from_app_json_basic_deserialization(basic_app_data, create_app_json):
     assert result.app_version == "1.0.0"
     assert result.package_name == "test_package"
     assert result.project_name == "test_app"  # Should be derived from parent directory
+
+
+def test_action_lock_round_trip_through_deserializer():
+    action_data = {
+        "action": "update configuration",
+        "identifier": "update_configuration",
+        "description": "Update configuration",
+        "type": "generic",
+        "read_only": False,
+        "versions": "EQ(*)",
+        "parameters": {},
+        "output": [],
+        "lock": {
+            "enabled": True,
+            "concurrency": False,
+            "data_path": "configuration.server",
+            "timeout": 600,
+        },
+    }
+
+    result = ActionDeserializer.from_action_json(action_data)
+
+    assert result.action_meta.lock == ActionLock(
+        concurrency=False,
+        data_path="configuration.server",
+        timeout=600,
+    )
+    assert result.action_meta.model_dump()["lock"] == action_data["lock"]
+
+    rendered_action = next(
+        block
+        for block in ActionRenderer(result.action_meta).render_ast()
+        if isinstance(block, ast.FunctionDef)
+    )
+    assert (
+        ast.unparse(rendered_action.decorator_list[0])
+        == "app.action(description='Update configuration', action_type='generic', read_only=False, lock=ActionLock(concurrency=False, data_path='configuration.server', timeout=600))"
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/cli/test_deserializers.py
+++ b/tests/cli/test_deserializers.py
@@ -13,7 +13,7 @@ from soar_sdk.cli.manifests.deserializers import (
 from soar_sdk.cli.manifests.serializers import OutputsSerializer
 from soar_sdk.code_renderers.action_renderer import ActionRenderer
 from soar_sdk.compat import PythonVersion
-from soar_sdk.meta.actions import ActionLock, ActionMeta
+from soar_sdk.meta.actions import ActionMeta
 from soar_sdk.meta.app import AppMeta
 from soar_sdk.params import Params
 
@@ -100,7 +100,7 @@ def test_from_app_json_basic_deserialization(basic_app_data, create_app_json):
     assert result.project_name == "test_app"  # Should be derived from parent directory
 
 
-def test_action_lock_round_trip_through_deserializer():
+def test_action_lock_deserializer_ignores_lock():
     action_data = {
         "action": "update configuration",
         "identifier": "update_configuration",
@@ -120,12 +120,8 @@ def test_action_lock_round_trip_through_deserializer():
 
     result = ActionDeserializer.from_action_json(action_data)
 
-    assert result.action_meta.lock == ActionLock(
-        concurrency=False,
-        data_path="configuration.server",
-        timeout=600,
-    )
-    assert result.action_meta.model_dump()["lock"] == action_data["lock"]
+    assert result.action_meta.lock is None
+    assert "lock" not in result.action_meta.model_dump()
 
     rendered_action = next(
         block
@@ -134,7 +130,7 @@ def test_action_lock_round_trip_through_deserializer():
     )
     assert (
         ast.unparse(rendered_action.decorator_list[0])
-        == "app.action(description='Update configuration', action_type='generic', read_only=False, lock=ActionLock(concurrency=False, data_path='configuration.server', timeout=600))"
+        == "app.action(description='Update configuration', action_type='generic', read_only=False)"
     )
 
 

--- a/tests/code_renderers/test_action_renderer.py
+++ b/tests/code_renderers/test_action_renderer.py
@@ -222,14 +222,12 @@ def test_render_action_verbose(action_meta) -> None:
 
 def test_render_action_lock(action_meta) -> None:
     action_meta.lock = ActionLock(
-        enabled=False,
-        concurrency=False,
         data_path="configuration.server",
         timeout=600,
     )
     expected_action = "\n".join(
         [
-            "@app.action(description='An example action for testing.', action_type='example', read_only=False, lock=ActionLock(enabled=False, concurrency=False, data_path='configuration.server', timeout=600))",
+            "@app.action(description='An example action for testing.', action_type='example', read_only=False, lock=ActionLock(data_path='configuration.server', timeout=600))",
             "def example_action(params: ExampleParams, soar: SOARClient, asset: Asset) -> ExampleActionOutput:",
             "    raise NotImplementedError()",
         ]

--- a/tests/code_renderers/test_action_renderer.py
+++ b/tests/code_renderers/test_action_renderer.py
@@ -5,7 +5,7 @@ import pytest
 
 from soar_sdk.action_results import ActionOutput, OutputField
 from soar_sdk.code_renderers.action_renderer import ActionRenderer
-from soar_sdk.meta.actions import ActionMeta
+from soar_sdk.meta.actions import ActionLock, ActionMeta
 from soar_sdk.params import Param, Params
 
 
@@ -218,6 +218,42 @@ def test_render_action_verbose(action_meta) -> None:
     }
 
     assert blocks["example_action"] == expected_action
+
+
+def test_render_action_lock(action_meta) -> None:
+    action_meta.lock = ActionLock(
+        enabled=False,
+        concurrency=False,
+        data_path="configuration.server",
+        timeout=600,
+    )
+    expected_action = "\n".join(
+        [
+            "@app.action(description='An example action for testing.', action_type='example', read_only=False, lock=ActionLock(enabled=False, concurrency=False, data_path='configuration.server', timeout=600))",
+            "def example_action(params: ExampleParams, soar: SOARClient, asset: Asset) -> ExampleActionOutput:",
+            "    raise NotImplementedError()",
+        ]
+    )
+
+    renderer = ActionRenderer(action_meta)
+    blocks = {
+        getattr(block, "name", "<UNKNOWN FIELD>"): ast.unparse(block)
+        for block in renderer.render_ast()
+    }
+
+    assert blocks["example_action"] == expected_action
+
+
+def test_render_action_lock_defaults(action_meta) -> None:
+    action_meta.lock = ActionLock()
+
+    renderer = ActionRenderer(action_meta)
+    blocks = {
+        getattr(block, "name", "<UNKNOWN FIELD>"): ast.unparse(block)
+        for block in renderer.render_ast()
+    }
+
+    assert "lock=ActionLock()" in blocks["example_action"]
 
 
 def test_render_action_read_only(action_meta) -> None:

--- a/tests/meta/test_actions.py
+++ b/tests/meta/test_actions.py
@@ -110,7 +110,6 @@ def test_action_meta_dict_with_complete_lock_metadata():
         type="generic",
         read_only=False,
         lock=ActionLock(
-            concurrency=False,
             data_path="configuration.server",
             timeout=600,
         ),
@@ -138,9 +137,16 @@ def test_action_meta_rejects_ambiguous_lock_configuration():
             description="Test description",
             type="generic",
             read_only=False,
-            lock=ActionLock(concurrency=False),
+            lock=ActionLock(),
             enable_concurrency_lock=True,
         )
+
+
+@pytest.mark.parametrize("field", ["enabled", "concurrency"])
+def test_action_lock_rejects_platform_managed_fields(field):
+    """Test that platform-managed lock fields are not configurable."""
+    with pytest.raises(ValidationError):
+        ActionLock(**{field: False})
 
 
 def test_action_lock_allows_zero_timeout():

--- a/tests/meta/test_actions.py
+++ b/tests/meta/test_actions.py
@@ -81,7 +81,7 @@ def test_action_meta_dict_with_concurrency_lock():
 
     with pytest.warns(
         DeprecationWarning,
-        match="enable_concurrency_lock is deprecated; use lock=ActionLock",
+        match="enable_concurrency_lock is deprecated",
     ):
         meta = ActionMeta(
             action="test_action",
@@ -96,8 +96,7 @@ def test_action_meta_dict_with_concurrency_lock():
 
     result = meta.model_dump()
 
-    assert "lock" in result
-    assert result["lock"]["enabled"] is True
+    assert result["lock"] == {"enabled": True}
     assert "enable_concurrency_lock" not in result
 
 

--- a/tests/meta/test_actions.py
+++ b/tests/meta/test_actions.py
@@ -143,7 +143,18 @@ def test_action_meta_rejects_ambiguous_lock_configuration():
         )
 
 
-def test_action_lock_requires_positive_timeout():
-    """Test that invalid lock acquisition timeouts are rejected."""
+def test_action_lock_allows_zero_timeout():
+    """Test that a no-wait lock acquisition timeout is accepted."""
+    assert ActionLock(timeout=0).timeout == 0
+
+
+def test_action_lock_rejects_negative_timeout():
+    """Test that negative lock acquisition timeouts are rejected."""
     with pytest.raises(ValidationError):
-        ActionLock(timeout=0)
+        ActionLock(timeout=-1)
+
+
+def test_action_lock_rejects_empty_data_path():
+    """Test that an explicit lock name cannot be empty."""
+    with pytest.raises(ValidationError):
+        ActionLock(data_path="")

--- a/tests/meta/test_actions.py
+++ b/tests/meta/test_actions.py
@@ -1,4 +1,7 @@
-from soar_sdk.meta.actions import ActionMeta
+import pytest
+from pydantic import ValidationError
+
+from soar_sdk.meta.actions import ActionLock, ActionMeta
 
 
 def test_action_meta_dict_with_view_handler():
@@ -92,3 +95,51 @@ def test_action_meta_dict_with_concurrency_lock():
     assert "lock" in result
     assert result["lock"]["enabled"] is True
     assert "enable_concurrency_lock" not in result
+
+
+def test_action_meta_dict_with_complete_lock_metadata():
+    """Test serialization of the complete action synchronization schema."""
+    meta = ActionMeta(
+        action="test_action",
+        identifier="test_identifier",
+        description="Test description",
+        type="generic",
+        read_only=False,
+        lock=ActionLock(
+            concurrency=False,
+            data_path="configuration.server",
+            timeout=600,
+        ),
+    )
+
+    result = meta.model_dump()
+
+    assert result["lock"] == {
+        "enabled": True,
+        "concurrency": False,
+        "data_path": "configuration.server",
+        "timeout": 600,
+    }
+
+
+def test_action_meta_rejects_ambiguous_lock_configuration():
+    """Test that the legacy flag cannot be combined with typed lock metadata."""
+    with pytest.raises(
+        ValidationError,
+        match="lock and enable_concurrency_lock cannot both be configured",
+    ):
+        ActionMeta(
+            action="test_action",
+            identifier="test_identifier",
+            description="Test description",
+            type="generic",
+            read_only=False,
+            lock=ActionLock(concurrency=False),
+            enable_concurrency_lock=True,
+        )
+
+
+def test_action_lock_requires_positive_timeout():
+    """Test that invalid lock acquisition timeouts are rejected."""
+    with pytest.raises(ValidationError):
+        ActionLock(timeout=0)

--- a/tests/meta/test_actions.py
+++ b/tests/meta/test_actions.py
@@ -79,16 +79,20 @@ def test_action_meta_dict_without_view_handler():
 def test_action_meta_dict_with_concurrency_lock():
     """Test ActionMeta.dict() with enable_concurrency_lock set to True."""
 
-    meta = ActionMeta(
-        action="test_action",
-        identifier="test_identifier",
-        description="Test description",
-        verbose="Test verbose",
-        type="generic",
-        read_only=True,
-        versions="EQ(*)",
-        enable_concurrency_lock=True,
-    )
+    with pytest.warns(
+        DeprecationWarning,
+        match="enable_concurrency_lock is deprecated; use lock=ActionLock",
+    ):
+        meta = ActionMeta(
+            action="test_action",
+            identifier="test_identifier",
+            description="Test description",
+            verbose="Test verbose",
+            type="generic",
+            read_only=True,
+            versions="EQ(*)",
+            enable_concurrency_lock=True,
+        )
 
     result = meta.model_dump()
 

--- a/tests/test_app_action.py
+++ b/tests/test_app_action.py
@@ -12,6 +12,7 @@ from soar_sdk.abstract import SOARClient
 from soar_sdk.action_results import ActionOutput
 from soar_sdk.app import App
 from soar_sdk.exceptions import ActionFailure, ActionRegistrationError
+from soar_sdk.meta.actions import ActionLock
 from soar_sdk.params import Param, Params
 from tests.stubs import SampleActionParams, SampleNestedOutput, SampleOutput
 
@@ -428,6 +429,28 @@ def test_register_action_basic(simple_app: App):
     actions = simple_app.get_actions()
     assert "importable_action" in actions
     assert actions["importable_action"] == registered_action
+
+
+def test_register_action_with_lock(simple_app: App):
+    def locked_action(params: Params) -> ActionOutput:
+        return ActionOutput()
+
+    registered_action = simple_app.register_action(
+        locked_action,
+        identifier="locked_action",
+        lock=ActionLock(
+            concurrency=False,
+            data_path="configuration.server",
+            timeout=600,
+        ),
+    )
+
+    assert registered_action.meta.model_dump()["lock"] == {
+        "enabled": True,
+        "concurrency": False,
+        "data_path": "configuration.server",
+        "timeout": 600,
+    }
 
 
 @pytest.mark.parametrize(

--- a/tests/test_app_action.py
+++ b/tests/test_app_action.py
@@ -439,7 +439,6 @@ def test_register_action_with_lock(simple_app: App):
         locked_action,
         identifier="locked_action",
         lock=ActionLock(
-            concurrency=False,
             data_path="configuration.server",
             timeout=600,
         ),

--- a/tests/test_code_renderers.py
+++ b/tests/test_code_renderers.py
@@ -96,6 +96,40 @@ def test_app_renderer():
     assert main_check is not None
 
 
+def test_app_renderer_imports_action_lock_when_used():
+    context = app_renderer.AppContext(
+        name="test_app",
+        app_type="ingestion",
+        logo="logo.png",
+        logo_dark="logo_dark.png",
+        product_vendor="Test Vendor",
+        product_name="Test Product",
+        publisher="Test Publisher",
+        appid="test_app_123",
+        fips_compliant=True,
+        app_content=[
+            ast.Expr(
+                value=ast.Call(
+                    func=ast.Name(id="ActionLock", ctx=ast.Load()),
+                    args=[],
+                    keywords=[],
+                )
+            )
+        ],
+    )
+
+    rendered = app_renderer.AppRenderer(context).render()
+    imports = [
+        statement
+        for statement in rendered.body
+        if isinstance(statement, ast.ImportFrom)
+        and statement.module == "soar_sdk.meta.actions"
+    ]
+
+    assert len(imports) == 1
+    assert [alias.name for alias in imports[0].names] == ["ActionLock"]
+
+
 def test_toml_renderer(mock_jinja_env):
     context = toml_renderer.TomlContext(
         name="test_app",


### PR DESCRIPTION
## Features

- Add a typed `ActionLock` model representing the complete Splunk SOAR action synchronization contract:
  - `enabled`
  - `concurrency`
  - `data_path`
  - `timeout`
- Accept `lock=ActionLock(...)` through both `App.action()` and `App.register_action()`.
- Preserve complete lock metadata when `soarapps convert` deserializes and renders an existing app manifest.
- Import `ActionLock` in generated code only when it is used.
- Document action synchronization using a read-modify-write example.

## Bug Fixes

The SDK previously represented an action lock using only:

```json
{
  "lock": {
    "enabled": true
  }
}
```

This enabled locking but could not express the complete platform contract. It discarded:

- `concurrency: false`, which is required to serialize overlapping executions.
- `data_path`, which determines the shared synchronization key.
- `timeout`, which bounds how long an execution waits to acquire the lock.

## Motivation

Mutating actions often perform a read-modify-write sequence against a remote service.

When two executions overlap, both may read the same initial state, independently modify it, and then write their results. The later write can silently discard the earlier update.

Splunk SOAR supports action manifest metadata that prevents this:

```python
lock=ActionLock(
    concurrency=False,
    data_path="configuration.server",
    timeout=600,
)
```

This generates:

```json
{
  "lock": {
    "enabled": true,
    "concurrency": false,
    "data_path": "configuration.server",
    "timeout": 600
  }
}
```

The platform contract is documented in [[Add and configure apps and assets](https://help.splunk.com/en/splunk-soar/soar-on-premises/administer-soar-on-premises/7.1.0/manage-your-splunk-soar-on-premises-apps-and-assets/add-and-configure-apps-and-assets-to-provide-actions-in-splunk-soar-on-premises)](https://help.splunk.com/en/splunk-soar/soar-on-premises/administer-soar-on-premises/7.1.0/manage-your-splunk-soar-on-premises-apps-and-assets/add-and-configure-apps-and-assets-to-provide-actions-in-splunk-soar-on-premises).

## Design

`ActionLock` provides an explicit, validated representation of the supported manifest fields.

- `enabled` defaults to `true`.
- Optional fields are omitted rather than serialized as `null`.
- `timeout` must be a positive integer.
- The same type is accepted by decorator-based and dynamic action registration.
- Converted apps retain their original lock contract.

## Backward Compatibility

- Existing `enable_concurrency_lock=True` callers remain supported.
- The legacy argument continues to serialize as `{"enabled": true}`.
- Combining `enable_concurrency_lock=True` with `lock=ActionLock(...)` is rejected because the configuration is ambiguous.
- Apps without lock metadata retain their current generated imports and manifests.

## Conversion Behavior

A deterministic round-trip test verifies that a manifest containing all four lock fields:

1. Deserializes into `ActionMeta`.
2. Serializes back to the same manifest contract.
3. Renders an `@app.action(lock=ActionLock(...))` decorator without field drift.

## Validation

- `uv run --locked pytest -n auto -m "not integration"` — **1313 passed**, 100% coverage
- Focused affected test suite — **113 passed**
- Python 3.13 type checking — passed
- Python 3.14 type checking — passed
- `uv run pre-commit run --all-files` — passed
  - Merge-conflict checks
  - YAML, JSON, and TOML checks
  - Ruff
  - Ruff formatting
  - pydocstyle
  - codespell
  - `uv-lock`
  - `ty`
- Sphinx HTML documentation build — passed
- `git diff --check` — passed

## Pull Request Checklist

- [x] I have added or updated unit tests where appropriate.
- [x] I have updated documentation and example apps where appropriate.
- [x] My commit messages adhere to the [[Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)](https://www.conventionalcommits.org/en/v1.0.0/) standard.
- [ ] All GitHub Actions and Pre-Commit checks have completed successfully.

## Legal Notice

By submitting a Contribution to this Work, You agree that Your Contribution is made subject to the primary license in the [[Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)](https://www.apache.org/licenses/LICENSE-2.0.txt). In addition, You represent that:

1. You are the copyright owner of the Contribution; or
2. You have the requisite rights to make the Contribution.

### Definitions

“You” shall mean:

1. Yourself if you are making a Contribution on your own behalf; or
2. Your company, if you are making a Contribution on behalf of your company.

If you are making a Contribution on behalf of your company, you represent that you have the requisite authority to do so.

“Contribution” shall mean any original work of authorship, including any modifications or additions to an existing work, that is intentionally submitted by You for inclusion in, or documentation of, this project or repository.

“Work” shall mean the collective software, content, and documentation in this project or repository.