### PR TITLE
fix: make polling persistence transactional

### DIFF
--- a/src/soar_sdk/app.py
+++ b/src/soar_sdk/app.py
@@ -722,7 +722,9 @@ class App:
         """
         if type(result) is list or isinstance(result, Iterator):
             if flatten_results:
-                param_dict = action_params.model_dump() if action_params else None
+                param_dict = (
+                    action_params.model_dump_for_result() if action_params else None
+                )
                 action_result = ActionResult(
                     status=True,
                     message=message,
@@ -753,7 +755,9 @@ class App:
 
         if isinstance(result, ActionOutput):
             output_dict = result.model_dump(by_alias=True)
-            param_dict = action_params.model_dump() if action_params else None
+            param_dict = (
+                action_params.model_dump_for_result() if action_params else None
+            )
 
             result = ActionResult(
                 status=True,

--- a/src/soar_sdk/asset_state.py
+++ b/src/soar_sdk/asset_state.py
@@ -52,7 +52,11 @@ class AssetState(MutableMapping[AssetStateKeyType, AssetStateValueType]):
             raise RuntimeError("No active transaction")
         buffered = self._transaction_buffer
         self._transaction_buffer = None
-        self.put_all(buffered)
+        try:
+            self.put_all(buffered)
+        except Exception:
+            self._transaction_buffer = buffered
+            raise
 
     def rollback(self) -> None:
         """Discard buffered writes."""

--- a/src/soar_sdk/decorators/on_poll.py
+++ b/src/soar_sdk/decorators/on_poll.py
@@ -25,7 +25,9 @@ def _flush_artifact_buffer(
         return
     if "run_automation" not in artifact_buffer[-1]:
         artifact_buffer[-1]["run_automation"] = True
-    save_artifacts(artifact_buffer.copy())
+    save_result = save_artifacts(artifact_buffer.copy())
+    if save_result is not None and not save_result[0]:
+        raise ActionFailure(f"Failed to save artifacts: {save_result[1]}")
     for a in artifact_buffer:
         logger.info(f"Added artifact: {a.get('name', 'Unnamed artifact')}")
     artifact_buffer.clear()
@@ -89,6 +91,8 @@ class OnPollDecorator:
             from soar_sdk.models.artifact import Artifact
             from soar_sdk.models.container import Container
 
+            ingest_state = None
+            owns_state_transaction = False
             try:
                 # Validate poll params
                 try:
@@ -103,6 +107,11 @@ class OnPollDecorator:
                     )
 
                 kwargs = self.app._build_magic_args(function, soar=soar, **kwargs)
+
+                ingest_state = self.app.asset.ingest_state
+                if not ingest_state.in_transaction:
+                    ingest_state.begin_transaction()
+                    owns_state_transaction = True
 
                 result = function(action_params, *args, **kwargs)
                 result = run_async_if_needed(result)
@@ -141,6 +150,8 @@ class OnPollDecorator:
                             container_id = cid
                             container_created = True
                             item.container_id = container_id
+                        else:
+                            raise ActionFailure(f"Failed to save container: {message}")
 
                         # Covered by test_on_poll::test_on_poll_yields_container_duplicate, but branch coverage detection on generator functions is wonky
                         if is_duplicate:  # pragma: no cover
@@ -183,17 +194,33 @@ class OnPollDecorator:
                     logger,
                 )
 
+                if owns_state_transaction:
+                    ingest_state.commit()
+                    owns_state_transaction = False
+
                 return self.app._adapt_action_result(
                     ActionResult(status=True, message="Polling complete"),
                     self.app.actions_manager,
                 )
             except ActionFailure as e:
+                if (
+                    owns_state_transaction
+                    and ingest_state is not None
+                    and ingest_state.in_transaction
+                ):
+                    ingest_state.rollback()
                 e.set_action_name(action_name)
                 return self.app._adapt_action_result(
                     ActionResult(status=False, message=str(e)),
                     self.app.actions_manager,
                 )
             except Exception as e:
+                if (
+                    owns_state_transaction
+                    and ingest_state is not None
+                    and ingest_state.in_transaction
+                ):
+                    ingest_state.rollback()
                 self.app.actions_manager.add_exception(e)
                 logger.info(f"Error during polling: {e!s}")
                 return self.app._adapt_action_result(

--- a/src/soar_sdk/decorators/on_poll.py
+++ b/src/soar_sdk/decorators/on_poll.py
@@ -150,8 +150,6 @@ class OnPollDecorator:
                             container_id = cid
                             container_created = True
                             item.container_id = container_id
-                        else:
-                            raise ActionFailure(f"Failed to save container: {message}")
 
                         # Covered by test_on_poll::test_on_poll_yields_container_duplicate, but branch coverage detection on generator functions is wonky
                         if is_duplicate:  # pragma: no cover

--- a/src/soar_sdk/params.py
+++ b/src/soar_sdk/params.py
@@ -146,6 +146,20 @@ class Params(BaseModel):
         words = field_name.split("_")
         return " ".join(words).title()
 
+    def model_dump_for_result(self) -> dict[str, Any]:
+        """Serialize action parameters without fields declared sensitive.
+
+        Action parameters are persisted with the action result for display and
+        playbook access. Password-typed values must not be copied into that
+        long-lived result record.
+        """
+        sensitive_fields = {
+            field_name
+            for field_name, field in self.__class__.model_fields.items()
+            if parse_json_schema_extra(field.json_schema_extra).get("sensitive", False)
+        }
+        return self.model_dump(exclude=sensitive_fields)
+
     @classmethod
     def _to_json_schema(cls) -> dict[str, InputFieldSpecification]:
         params: dict[str, InputFieldSpecification] = {}

--- a/tests/test_asset_state.py
+++ b/tests/test_asset_state.py
@@ -154,6 +154,26 @@ def test_transaction_commit_persists(example_state: AssetState):
     assert example_state.get_all() == {"key": "updated", "new_key": "new_value"}
 
 
+def test_transaction_commit_failure_preserves_buffer_for_rollback(
+    example_state: AssetState, monkeypatch: pytest.MonkeyPatch
+):
+    example_state.put_all({"key": "original"})
+    example_state.begin_transaction()
+    example_state["key"] = "updated"
+
+    def fail_save(_state):
+        raise OSError("disk full")
+
+    monkeypatch.setattr(example_state.backend, "save_state", fail_save)
+
+    with pytest.raises(OSError, match="disk full"):
+        example_state.commit()
+
+    assert example_state.in_transaction
+    assert example_state.get_all() == {"key": "updated"}
+    example_state.rollback()
+
+
 def test_transaction_rollback_discards(example_state: AssetState):
     example_state.put_all({"key": "original"})
 

--- a/tests/test_on_poll.py
+++ b/tests/test_on_poll.py
@@ -271,6 +271,110 @@ def test_on_poll_yields_container_creation_failure(
     assert generator_resumed is False
 
 
+def test_on_poll_rolls_back_ingest_state_when_artifact_save_fails(
+    app_with_action: App, mocker: pytest_mock.MockerFixture
+):
+    """A failed artifact save must not commit a checkpoint written by the app."""
+    mocker.patch.object(
+        app_with_action.actions_manager,
+        "save_container",
+        return_value=(True, "Created", 42),
+    )
+    mocker.patch.object(
+        app_with_action.actions_manager,
+        "save_artifacts",
+        return_value=(False, "Rejected", None),
+    )
+
+    @app_with_action.on_poll()
+    def on_poll_function(params: OnPollParams):
+        yield Container(name="c1")
+        yield Artifact(name="a1")
+        app_with_action.asset.ingest_state["checkpoint"] = 100
+
+    result = on_poll_function(OnPollParams(start_time=0, end_time=1))
+
+    assert result is False
+    assert "checkpoint" not in app_with_action.asset.ingest_state
+
+
+def test_on_poll_commits_ingest_state_after_successful_saves(
+    app_with_action: App, mocker: pytest_mock.MockerFixture
+):
+    """A checkpoint is committed only after its container and artifacts are durable."""
+    mocker.patch.object(
+        app_with_action.actions_manager,
+        "save_container",
+        return_value=(True, "Created", 42),
+    )
+    mocker.patch.object(
+        app_with_action.actions_manager,
+        "save_artifacts",
+        return_value=(True, "Created", [1]),
+    )
+
+    @app_with_action.on_poll()
+    def on_poll_function(params: OnPollParams):
+        yield Container(name="c1")
+        yield Artifact(name="a1")
+        app_with_action.asset.ingest_state["checkpoint"] = 100
+
+    result = on_poll_function(OnPollParams(start_time=0, end_time=1))
+
+    assert result is True
+    assert app_with_action.asset.ingest_state["checkpoint"] == 100
+
+
+def test_on_poll_respects_an_existing_ingest_state_transaction(
+    app_with_action: App,
+):
+    ingest_state = app_with_action.asset.ingest_state
+    ingest_state.begin_transaction()
+
+    @app_with_action.on_poll()
+    def on_poll_function(params: OnPollParams):
+        ingest_state["checkpoint"] = 100
+        yield
+
+    result = on_poll_function(OnPollParams(start_time=0, end_time=1))
+
+    assert result is True
+    assert ingest_state.in_transaction
+    ingest_state.rollback()
+
+
+def test_on_poll_handles_action_failure_before_state_transaction(
+    app_with_action: App, mocker: pytest_mock.MockerFixture
+):
+    mocker.patch.object(
+        app_with_action,
+        "_build_magic_args",
+        side_effect=ActionFailure("argument failure"),
+    )
+
+    @app_with_action.on_poll()
+    def on_poll_function(params: OnPollParams):
+        yield
+
+    assert on_poll_function(OnPollParams(start_time=0, end_time=1)) is False
+
+
+def test_on_poll_handles_exception_before_state_transaction(
+    app_with_action: App, mocker: pytest_mock.MockerFixture
+):
+    mocker.patch.object(
+        app_with_action,
+        "_build_magic_args",
+        side_effect=RuntimeError("argument failure"),
+    )
+
+    @app_with_action.on_poll()
+    def on_poll_function(params: OnPollParams):
+        yield
+
+    assert on_poll_function(OnPollParams(start_time=0, end_time=1)) is False
+
+
 def test_on_poll_sets_run_automation_on_last_artifact_per_container(
     app_with_action: App, mocker: pytest_mock.MockerFixture
 ):

--- a/tests/test_on_poll.py
+++ b/tests/test_on_poll.py
@@ -238,6 +238,31 @@ def test_on_poll_yields_container_duplicate(
     save_artifacts.assert_called()
 
 
+def test_on_poll_yields_container_duplicate_failure_response(
+    app_with_action: App, mocker: pytest_mock.MockerFixture
+):
+    """A duplicate response may report false without failing the poll."""
+    save_container = mocker.patch.object(
+        app_with_action.actions_manager,
+        "save_container",
+        return_value=(False, "Duplicate container found", None),
+    )
+
+    generator_resumed = False
+
+    @app_with_action.on_poll()
+    def on_poll_function_dup(params: OnPollParams, client=None):
+        nonlocal generator_resumed
+        yield Container(name="c2")
+        generator_resumed = True
+
+    params = OnPollParams(start_time=0, end_time=1)
+    result = on_poll_function_dup(params, client=app_with_action.soar_client)
+    assert result is True
+    assert save_container.call_count == 1
+    assert generator_resumed is True
+
+
 def test_on_poll_yields_container_creation_failure(
     app_with_action: App, mocker: pytest_mock.MockerFixture
 ):

--- a/tests/test_params.py
+++ b/tests/test_params.py
@@ -20,6 +20,19 @@ def test_sensitive_param_must_be_str():
     assert e.match("Sensitive parameter secret must be type str, not bool")
 
 
+def test_model_dump_for_result_omits_sensitive_parameters():
+    class SecretParams(Params):
+        username: str = Param()
+        password: str = Param(sensitive=True)
+        aliased_secret: str = Param(sensitive=True, alias="api_token")
+
+    params = SecretParams(
+        username="analyst", password="secret", api_token="another-secret"
+    )
+
+    assert params.model_dump_for_result() == {"username": "analyst"}
+
+
 def test_make_request_params_validation():
     """Test that MakeRequestParams validates fields on instantiation in Pydantic v2."""
 


### PR DESCRIPTION
## Summary

- omit parameters declared sensitive from serialized action-result payloads
- commit polling checkpoints only after container and artifact persistence succeeds
- restore buffered state when a checkpoint write fails
- preserve the accepted duplicate-container response while rejecting genuine save failures

## Tracking

- Parent: [ESPM-5228](https://splunk.atlassian.net/browse/ESPM-5228)
- CrowdStrike implementation: [PAPP-37947](https://splunk.atlassian.net/browse/PAPP-37947)
- CrowdStrike poll checkpoint persistence: [PSAAS-31835](https://splunk.atlassian.net/browse/PSAAS-31835)
- CrowdStrike sensitive parameter persistence: [PSAAS-31874](https://splunk.atlassian.net/browse/PSAAS-31874)
- Gmail implementation: [PAPP-37990](https://splunk.atlassian.net/browse/PAPP-37990)
- Gmail poll checkpoint persistence: [PSAAS-32327](https://splunk.atlassian.net/browse/PSAAS-32327)
- Exchange EWS implementation: [PAPP-38269](https://splunk.atlassian.net/browse/PAPP-38269)
- Exchange EWS poll checkpoint persistence: [PSAAS-32319](https://splunk.atlassian.net/browse/PSAAS-32319)
- Microsoft 365 Defender implementation: [PAPP-38240](https://splunk.atlassian.net/browse/PAPP-38240)
- Microsoft 365 Defender poll checkpoint persistence: [PSAAS-32189](https://splunk.atlassian.net/browse/PSAAS-32189)

## Dependency

This PR is intentionally stacked on #238, which supplies the initial container-save failure handling. Once #238 merges, this PR should be retargeted or rebased onto `main` without squashing commits.

## Quality gate

- `uv run pytest -q`: 1320 passed, 17 skipped, 100% coverage
- `uv run pre-commit run --all-files`: passed

Created by Codex.
