### PR TITLE
fix: preserve artifacts across duplicate-container retries

### DIFF
--- a/src/soar_sdk/decorators/on_poll.py
+++ b/src/soar_sdk/decorators/on_poll.py
@@ -146,7 +146,11 @@ class OnPollDecorator:
                                 f"Failed to create container: {message}"
                             )
 
-                        if ret_val:
+                        if ret_val or is_duplicate:
+                            if cid is None:
+                                raise ActionFailure(
+                                    "Failed to reuse duplicate container: no container ID was returned"
+                                )
                             container_id = cid
                             container_created = True
                             item.container_id = container_id

--- a/tests/test_on_poll.py
+++ b/tests/test_on_poll.py
@@ -241,7 +241,7 @@ def test_on_poll_yields_container_duplicate(
 def test_on_poll_yields_container_duplicate_failure_response(
     app_with_action: App, mocker: pytest_mock.MockerFixture
 ):
-    """A duplicate response may report false without failing the poll."""
+    """A duplicate response without a container ID must fail the poll."""
     save_container = mocker.patch.object(
         app_with_action.actions_manager,
         "save_container",
@@ -258,9 +258,34 @@ def test_on_poll_yields_container_duplicate_failure_response(
 
     params = OnPollParams(start_time=0, end_time=1)
     result = on_poll_function_dup(params, client=app_with_action.soar_client)
-    assert result is True
+    assert result is False
     assert save_container.call_count == 1
-    assert generator_resumed is True
+    assert generator_resumed is False
+
+
+def test_on_poll_reuses_duplicate_container_id_for_artifacts(
+    app_with_action: App, mocker: pytest_mock.MockerFixture
+):
+    """A duplicate container ID is bound to subsequently yielded artifacts."""
+    mocker.patch.object(
+        app_with_action.actions_manager,
+        "save_container",
+        return_value=(False, "Duplicate container found", 99),
+    )
+    save_artifacts = mocker.patch.object(
+        app_with_action.actions_manager, "save_artifacts", return_value=None
+    )
+
+    @app_with_action.on_poll()
+    def on_poll_function_dup(params: OnPollParams, client=None):
+        yield Container(name="c2")
+        yield Artifact(name="a2")
+
+    result = on_poll_function_dup(OnPollParams(start_time=0, end_time=1))
+
+    assert result is True
+    saved = save_artifacts.call_args[0][0]
+    assert saved[0]["container_id"] == 99
 
 
 def test_on_poll_yields_container_creation_failure(


### PR DESCRIPTION
## Summary

- bind an existing container ID before retrying artifact persistence
- fail closed when a duplicate-container response has no usable ID
- preserve SOAR 8.6 platform handling and automation datapaths for sensitive parameters

## Tracking

- ESPM-5228
- follow-up to merged PR #238

## Scope correction

The branch history is consolidated into one release-producing commit for the duplicate-container retry fix. Sensitive input masking, persistence protection, and display authorization remain owned by the SOAR 8.6 platform contract; this PR does not remove parameter datapaths used by automation.

## Validation

- `uv run pytest`: 1,342 passed, 17 skipped, 100% coverage
- `uv run pre-commit run --all-files`: passed
- duplicate-container retry coverage verifies existing IDs are rebound and missing IDs fail closed
- all hosted checks passed, including current, previous, and next platform integration tests

Written by Codex.
